### PR TITLE
perf: Eliminate locale redirect latency (~1s savings)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -4,12 +4,13 @@ import { locales, defaultLocale } from "./src/i18n/config";
 export default createMiddleware({
   locales,
   defaultLocale,
-  localePrefix: "always",
+  localePrefix: "as-needed",
   localeDetection: true,
 });
 
 export const config = {
   matcher: [
-    "/(en|es|zh|ru)/:path*",
+    // Match all paths except static files and API routes
+    "/((?!api|_next|_vercel|.*\\..*).*)",
   ],
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -43,68 +43,19 @@ const nextConfig: NextConfig = {
   // Enable standalone output for Docker deployment
   output: "standalone",
 
-  // Redirects for non-locale paths to default locale
+  // Redirect /en/* to /* for SEO (avoid duplicate content)
+  // The middleware serves default locale content at / without prefix
   async redirects() {
     return [
       {
-        source: "/leaderboard",
-        destination: "/en/leaderboard",
-        permanent: false,
+        source: "/en",
+        destination: "/",
+        permanent: true,
       },
       {
-        source: "/analytics",
-        destination: "/en/analytics",
-        permanent: false,
-      },
-      {
-        source: "/graveyard",
-        destination: "/en/graveyard",
-        permanent: false,
-      },
-      {
-        source: "/portfolio",
-        destination: "/en/portfolio",
-        permanent: false,
-      },
-      {
-        source: "/map",
-        destination: "/en/map",
-        permanent: false,
-      },
-      {
-        source: "/alerts",
-        destination: "/en/alerts",
-        permanent: false,
-      },
-      {
-        source: "/reports",
-        destination: "/en/reports",
-        permanent: false,
-      },
-      {
-        source: "/nodes",
-        destination: "/en/nodes",
-        permanent: false,
-      },
-      {
-        source: "/nodes/:path*",
-        destination: "/en/nodes/:path*",
-        permanent: false,
-      },
-      {
-        source: "/settings/:path*",
-        destination: "/en/settings/:path*",
-        permanent: false,
-      },
-      {
-        source: "/privacy",
-        destination: "/en/privacy",
-        permanent: false,
-      },
-      {
-        source: "/terms",
-        destination: "/en/terms",
-        permanent: false,
+        source: "/en/:path*",
+        destination: "/:path*",
+        permanent: true,
       },
     ];
   },

--- a/src/i18n/navigation.ts
+++ b/src/i18n/navigation.ts
@@ -4,5 +4,5 @@ import { locales, defaultLocale } from "./config";
 export const { Link, redirect, usePathname, useRouter } = createNavigation({
   locales,
   defaultLocale,
-  localePrefix: "always",
+  localePrefix: "as-needed",
 });


### PR DESCRIPTION
## Summary
Lighthouse audit found 1079ms wasted on the `/` → `/en` redirect. This fix serves default locale content directly at `/` without any redirect.

## Changes
- `middleware.ts`: Changed `localePrefix` from `always` to `as-needed`, updated matcher
- `src/i18n/navigation.ts`: Matching `localePrefix` change
- `next.config.ts`: Replaced 12 redundant redirects with 2 SEO redirects (`/en/*` → `/*`)

## How it works now
| URL | Before | After |
|-----|--------|-------|
| `/` | Redirect to `/en` (1s delay) | Serves English content directly |
| `/es` | Serves Spanish | Serves Spanish (unchanged) |
| `/en/nodes` | Serves English | Redirects to `/nodes` (SEO) |
| `/nodes` | Redirect to `/en/nodes` | Serves English content directly |

## Expected Performance Impact
- **~1 second faster** initial page load
- Better Lighthouse performance score
- Cleaner URLs for default locale