### PR TITLE
fix(ci): pulse-api workflow buildx setup

### DIFF
--- a/.github/workflows/deploy-pulse-api.yml
+++ b/.github/workflows/deploy-pulse-api.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Required so build-push-action can use cache-from/cache-to: type=gha.
+      # The default docker driver does not support GHA cache export.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Why
First run of \`deploy-pulse-api.yml\` on the squash merge of #215 ([run 26505265976](https://github.com/RECTOR-LABS/pnode-pulse/actions/runs/26505265976)) failed in <1s:

\`\`\`
ERROR: failed to build: Cache export is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
\`\`\`

\`build-push-action\` is configured with \`cache-from: type=gha\` and \`cache-to: type=gha,mode=max\`, but no prior \`docker/setup-buildx-action\` step ran — so the default \`docker\` driver was used, which doesn't support the GHA cache exporter.

## What
One step added before the build:

\`\`\`yaml
- name: Set up Docker Buildx
  uses: docker/setup-buildx-action@v3
\`\`\`

That installs a \`docker-container\` builder that supports the gha cache exporter — the recommended pairing.

## Downstream caveat (intentional, not a blocker for this PR)
The SSH deploy step further down in the same workflow will still fail until \`JWT_SECRET\` is configured in the VPS \`.env\` (runbook step T2.2). That's a Tier 2 cutover prerequisite handled separately. This PR only unblocks the image **build + push** so the image is available in GHCR ahead of Tier 2.

## Test plan
- [ ] CI builds + pushes \`ghcr.io/rector-labs/pulse-api:latest\` for the squash commit (or the next pulse-api change)
- [ ] SSH deploy step is expected to fail at \`docker compose up\` until T2.2 is done — verify the failure is at that step and not the build step