### PR TITLE
fix(ci+pulse-api): ssh-agent auth + type Telegram response

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -55,19 +55,15 @@ jobs:
           sudo dpkg -i /tmp/cloudflared.deb
           cloudflared --version
 
-      - name: Configure SSH
-        run: |
-          mkdir -p ~/.ssh
-          chmod 700 ~/.ssh
-          printf '%s\n' "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
+      - name: Load VPS SSH key into ssh-agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.VPS_SSH_KEY }}
 
       - name: Deploy to VPS (Blue/Green Production via CF Tunnel)
         run: |
           ssh -o StrictHostKeyChecking=accept-new \
-              -o UserKnownHostsFile=~/.ssh/known_hosts \
               -o ProxyCommand="cloudflared access ssh --hostname=ssh.rectorspace.com" \
-              -i ~/.ssh/id_ed25519 \
               pnodepulse@ssh.rectorspace.com bash -s <<'REMOTE'
           set -euo pipefail
           cd ~/pnode-pulse
@@ -81,9 +77,7 @@ jobs:
       - name: Verify deployment
         run: |
           ssh -o StrictHostKeyChecking=accept-new \
-              -o UserKnownHostsFile=~/.ssh/known_hosts \
               -o ProxyCommand="cloudflared access ssh --hostname=ssh.rectorspace.com" \
-              -i ~/.ssh/id_ed25519 \
               pnodepulse@ssh.rectorspace.com bash -s <<'REMOTE'
           set -euo pipefail
           cd ~/pnode-pulse

--- a/.github/workflows/deploy-pulse-api.yml
+++ b/.github/workflows/deploy-pulse-api.yml
@@ -70,19 +70,15 @@ jobs:
           sudo dpkg -i /tmp/cloudflared.deb
           cloudflared --version
 
-      - name: Configure SSH
-        run: |
-          mkdir -p ~/.ssh
-          chmod 700 ~/.ssh
-          printf '%s\n' "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
+      - name: Load VPS SSH key into ssh-agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.VPS_SSH_KEY }}
 
       - name: Deploy pulse-api to VPS (via CF Tunnel)
         run: |
           ssh -o StrictHostKeyChecking=accept-new \
-              -o UserKnownHostsFile=~/.ssh/known_hosts \
               -o ProxyCommand="cloudflared access ssh --hostname=ssh.rectorspace.com" \
-              -i ~/.ssh/id_ed25519 \
               pnodepulse@ssh.rectorspace.com bash -s <<'REMOTE'
           set -euo pipefail
           cd ~/pnode-pulse
@@ -112,9 +108,7 @@ jobs:
       - name: Verify deployment
         run: |
           ssh -o StrictHostKeyChecking=accept-new \
-              -o UserKnownHostsFile=~/.ssh/known_hosts \
               -o ProxyCommand="cloudflared access ssh --hostname=ssh.rectorspace.com" \
-              -i ~/.ssh/id_ed25519 \
               pnodepulse@ssh.rectorspace.com bash -s <<'REMOTE'
           set -euo pipefail
           cd ~/pnode-pulse

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -54,19 +54,15 @@ jobs:
           sudo dpkg -i /tmp/cloudflared.deb
           cloudflared --version
 
-      - name: Configure SSH
-        run: |
-          mkdir -p ~/.ssh
-          chmod 700 ~/.ssh
-          printf '%s\n' "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
+      - name: Load VPS SSH key into ssh-agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.VPS_SSH_KEY }}
 
       - name: Deploy to VPS (Staging via CF Tunnel)
         run: |
           ssh -o StrictHostKeyChecking=accept-new \
-              -o UserKnownHostsFile=~/.ssh/known_hosts \
               -o ProxyCommand="cloudflared access ssh --hostname=ssh.rectorspace.com" \
-              -i ~/.ssh/id_ed25519 \
               pnodepulse@ssh.rectorspace.com bash -s <<'REMOTE'
           set -euo pipefail
           cd ~/pnode-pulse

--- a/packages/pulse-api/src/lib/notifications/service.ts
+++ b/packages/pulse-api/src/lib/notifications/service.ts
@@ -358,7 +358,14 @@ ${payload.message}
       },
     );
 
-    const result = await response.json();
+    // Telegram Bot API sendMessage response — only the fields we read.
+    // See https://core.telegram.org/bots/api#making-requests
+    interface TelegramSendMessageResponse {
+      ok: boolean;
+      description?: string;
+      result?: { message_id: number };
+    }
+    const result = (await response.json()) as TelegramSendMessageResponse;
 
     if (!result.ok) {
       throw new Error(result.description || "Telegram API error");
@@ -368,7 +375,7 @@ ${payload.message}
       success: true,
       channelType: "telegram",
       channelId,
-      messageId: String(result.result.message_id),
+      messageId: String(result.result?.message_id),
     };
   } catch (error) {
     return {


### PR DESCRIPTION
Two follow-ons from the first end-to-end run after PR #218 landed.

## 1. CI: SSH publickey rejected → switch to ssh-agent

[Run 26612188637](https://github.com/RECTOR-LABS/pnode-pulse/actions/runs/26612188637) confirmed the CF Tunnel path works (\`ssh.rectorspace.com\` added to known_hosts), but auth failed:

\`\`\`
pnodepulse@ssh.rectorspace.com: Permission denied (publickey).
\`\`\`

The hand-rolled \`printf '%s\n' \"\$KEY\" > id_ed25519\` from #218 was fragile around line endings / special chars in the secret. Replaced in all three deploy workflows with [\`webfactory/ssh-agent@v0.9.0\`](https://github.com/webfactory/ssh-agent), which loads the key into an in-memory agent the way \`appleboy/ssh-action\` used to do internally. No more on-disk private key, no bespoke shell.

## 2. pulse-api build: TS18046 on Telegram response

[Run 26612188658](https://github.com/RECTOR-LABS/pnode-pulse/actions/runs/26612188658) failed at \`npm run build\`:

\`\`\`
src/lib/notifications/service.ts(363,10): error TS18046: 'result' is of type 'unknown'.
\`\`\`

Local typecheck passes because we have \`@types/node 22.19.19\` where \`Response.json()\` still returns \`Promise<any>\`. CI installed a newer 22.x patch where it now returns \`Promise<unknown>\`. Added an inline \`TelegramSendMessageResponse\` interface and a typed cast at the call site. Monolith copy is intentionally not touched (additive lift).

## Verification
- [x] \`actionlint\` clean on all three workflows
- [x] pulse-api \`tsc --noEmit\` clean, 24/24 tests pass
- [x] Root 307/307 tests pass via pre-commit hook
- [ ] Merge → new runs on the merge commit → both deploys green