### PR TITLE
fix(pulse-api): Dockerfile Prisma COPY paths

### DIFF
--- a/packages/pulse-api/Dockerfile
+++ b/packages/pulse-api/Dockerfile
@@ -49,10 +49,12 @@ COPY --from=builder /app/packages/pulse-api/package.json ./package.json
 COPY --from=builder /app/packages/pulse-types ./packages/pulse-types
 RUN npm install --ignore-scripts --omit=dev
 
-# Generated Prisma client + schema
+# Generated Prisma client + schema. `npx prisma generate` was run from
+# /app/packages/pulse-api in the build stage, so the client landed in the
+# workspace-local node_modules — not the (non-existent) root one.
 COPY --from=builder /app/prisma ./prisma
-COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
-COPY --from=builder /app/node_modules/@prisma/client ./node_modules/@prisma/client
+COPY --from=builder /app/packages/pulse-api/node_modules/.prisma ./node_modules/.prisma
+COPY --from=builder /app/packages/pulse-api/node_modules/@prisma/client ./node_modules/@prisma/client
 
 # Compiled JS
 COPY --from=builder /app/packages/pulse-api/dist ./dist


### PR DESCRIPTION
## Why

[Run 26612443033](https://github.com/RECTOR-LABS/pnode-pulse/actions/runs/26612443033) — the first run where the pulse-api Docker build got past TypeScript — failed at the COPY of the generated Prisma client:

\`\`\`
failed to compute cache key: failed to calculate checksum of ref ...:
"/app/node_modules/.prisma": not found
\`\`\`

The build stage runs \`npx prisma generate\` from \`/app/packages/pulse-api\`, so the generated client lands in the workspace-local \`node_modules\`. The runtime stage was COPYing from \`/app/node_modules/*\` — a non-existent root.

## What

Two COPY paths corrected:

\`\`\`diff
-COPY --from=builder /app/node_modules/.prisma         ./node_modules/.prisma
-COPY --from=builder /app/node_modules/@prisma/client  ./node_modules/@prisma/client
+COPY --from=builder /app/packages/pulse-api/node_modules/.prisma         ./node_modules/.prisma
+COPY --from=builder /app/packages/pulse-api/node_modules/@prisma/client  ./node_modules/@prisma/client
\`\`\`

Comment added explaining where the client actually lives, so the next reader doesn't reintroduce it.

## Test plan
- [ ] Merge → next run on main builds + pushes \`ghcr.io/rector-labs/pulse-api:latest\` successfully
- [ ] SSH deploy step still expected to land on the VPS via \`docker compose up\` but to fail at pulse-api startup until JWT_SECRET is in VPS \`.env\` (Tier 2 prerequisite, runbook T2.2)