### PR TITLE
fix(db): widen node_peers.id to bigint (int4 sequence exhausted)

### DIFF
--- a/packages/pulse-api/src/server/routers/analytics/peers.ts
+++ b/packages/pulse-api/src/server/routers/analytics/peers.ts
@@ -42,7 +42,7 @@ export const peersRouter = createTRPCRouter({
       });
 
       const peerInfos: PeerInfo[] = peers.map((p) => ({
-        peerId: p.peerNodeId ?? p.id,
+        peerId: p.peerNodeId ?? Number(p.id),
         address: p.peerAddress,
         version: p.peerVersion ?? undefined,
         isActive: p.peerNode?.isActive ?? true, // Assume active if not linked
@@ -100,7 +100,7 @@ export const peersRouter = createTRPCRouter({
       allPeers.forEach((p) => {
         const peers = peersByNode.get(p.nodeId) ?? [];
         peers.push({
-          peerId: p.peerNodeId ?? p.id,
+          peerId: p.peerNodeId ?? Number(p.id),
           address: p.peerAddress,
           version: p.peerVersion ?? undefined,
           isActive: p.peerNode?.isActive ?? true,

--- a/packages/pulse-api/src/server/routers/nodes.ts
+++ b/packages/pulse-api/src/server/routers/nodes.ts
@@ -364,7 +364,9 @@ export const nodesRouter = createTRPCRouter({
       orderBy: { lastSeenAt: "desc" },
     });
 
-    return peers;
+    // NodePeer.id is BigInt in the DB; coerce to number to keep the API
+    // response contract (and avoid leaking bigint to clients).
+    return peers.map((p) => ({ ...p, id: Number(p.id) }));
   }),
 
   /**

--- a/prisma/migrations/20260529030500_node_peers_id_bigint/migration.sql
+++ b/prisma/migrations/20260529030500_node_peers_id_bigint/migration.sql
@@ -1,0 +1,15 @@
+-- Widen NodePeer.id (and its backing sequence) from int4 to bigint.
+--
+-- The autoincrement sequence `node_peers_id_seq` reached the int4 maximum
+-- (2147483647), so `prisma.nodePeer.upsert()` started failing with
+-- PostgresError 2200H ("nextval: reached maximum value of sequence"),
+-- aborting the collector's peer-update cycles. The sequence burns a value on
+-- every ON CONFLICT upsert (not just inserts), which exhausted int4 over time.
+--
+-- bigint removes the ceiling. NodePeer.id is a pure surrogate key (nothing
+-- foreign-keys to it), so widening it is safe. Note: this ALTER COLUMN rewrites
+-- the table under an ACCESS EXCLUSIVE lock — brief, but it does lock node_peers.
+
+ALTER TABLE "node_peers" ALTER COLUMN "id" SET DATA TYPE BIGINT;
+
+ALTER SEQUENCE "node_peers_id_seq" AS bigint MAXVALUE 9223372036854775807;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -248,7 +248,7 @@ model NodeMetric {
 
 /// Peer relationships between nodes (from get-pods)
 model NodePeer {
-  id            Int      @id @default(autoincrement())
+  id            BigInt   @id @default(autoincrement())
   nodeId        Int      @map("node_id")
   peerNodeId    Int?     @map("peer_node_id")
   /// Peer address if not yet registered as a node

--- a/src/server/api/routers/analytics/peers.ts
+++ b/src/server/api/routers/analytics/peers.ts
@@ -42,7 +42,7 @@ export const peersRouter = createTRPCRouter({
       });
 
       const peerInfos: PeerInfo[] = peers.map((p) => ({
-        peerId: p.peerNodeId ?? p.id,
+        peerId: p.peerNodeId ?? Number(p.id),
         address: p.peerAddress,
         version: p.peerVersion ?? undefined,
         isActive: p.peerNode?.isActive ?? true, // Assume active if not linked
@@ -62,9 +62,11 @@ export const peersRouter = createTRPCRouter({
    */
   networkConnectivity: publicProcedure
     .input(
-      z.object({
-        limit: z.number().min(1).max(200).default(100),
-      }).optional()
+      z
+        .object({
+          limit: z.number().min(1).max(200).default(100),
+        })
+        .optional(),
     )
     .query(async ({ ctx, input }) => {
       const limit = input?.limit ?? 100;
@@ -98,7 +100,7 @@ export const peersRouter = createTRPCRouter({
       allPeers.forEach((p) => {
         const peers = peersByNode.get(p.nodeId) ?? [];
         peers.push({
-          peerId: p.peerNodeId ?? p.id,
+          peerId: p.peerNodeId ?? Number(p.id),
           address: p.peerAddress,
           version: p.peerVersion ?? undefined,
           isActive: p.peerNode?.isActive ?? true,
@@ -127,10 +129,14 @@ export const peersRouter = createTRPCRouter({
    */
   peerOptimizations: publicProcedure
     .input(
-      z.object({
-        limit: z.number().min(1).max(100).default(50),
-        priorityFilter: z.enum(["all", "critical", "high", "medium"]).default("all"),
-      }).optional()
+      z
+        .object({
+          limit: z.number().min(1).max(100).default(50),
+          priorityFilter: z
+            .enum(["all", "critical", "high", "medium"])
+            .default("all"),
+        })
+        .optional(),
     )
     .query(async ({ ctx, input }) => {
       const limit = input?.limit ?? 50;
@@ -152,10 +158,12 @@ export const peersRouter = createTRPCRouter({
       });
 
       // Get active peer counts (peers that are also active nodes)
-      const activePeerCounts = await ctx.db.$queryRaw<Array<{
-        node_id: number;
-        active_peers: bigint;
-      }>>`
+      const activePeerCounts = await ctx.db.$queryRaw<
+        Array<{
+          node_id: number;
+          active_peers: bigint;
+        }>
+      >`
         SELECT
           np.node_id,
           COUNT(*) FILTER (WHERE n.is_active = true) as active_peers
@@ -167,10 +175,10 @@ export const peersRouter = createTRPCRouter({
       `;
 
       const totalPeerMap = new Map(
-        peerCounts.map((p) => [p.nodeId, p._count.id])
+        peerCounts.map((p) => [p.nodeId, p._count.id]),
       );
       const activePeerMap = new Map(
-        activePeerCounts.map((p) => [p.node_id, Number(p.active_peers)])
+        activePeerCounts.map((p) => [p.node_id, Number(p.active_peers)]),
       );
 
       // Create simplified analyses for optimization detection
@@ -179,7 +187,8 @@ export const peersRouter = createTRPCRouter({
         address: node.address,
         totalPeers: totalPeerMap.get(node.id) ?? 0,
         activePeers: activePeerMap.get(node.id) ?? 0,
-        inactivePeers: (totalPeerMap.get(node.id) ?? 0) - (activePeerMap.get(node.id) ?? 0),
+        inactivePeers:
+          (totalPeerMap.get(node.id) ?? 0) - (activePeerMap.get(node.id) ?? 0),
         versionDiversity: 0,
         peerVersions: [],
         healthScore: 50 + Math.min((activePeerMap.get(node.id) ?? 0) * 3, 40),
@@ -194,7 +203,7 @@ export const peersRouter = createTRPCRouter({
         const priorityOrder = { critical: 0, high: 1, medium: 2, low: 3 };
         const maxPriority = priorityOrder[priorityFilter];
         optimizations = optimizations.filter(
-          (o) => priorityOrder[o.priority] <= maxPriority
+          (o) => priorityOrder[o.priority] <= maxPriority,
         );
       }
 
@@ -206,7 +215,8 @@ export const peersRouter = createTRPCRouter({
         totalNodesAnalyzed: nodes.length,
         nodesNeedingOptimization: optimizations.length,
         byPriority: {
-          critical: optimizations.filter((o) => o.priority === "critical").length,
+          critical: optimizations.filter((o) => o.priority === "critical")
+            .length,
           high: optimizations.filter((o) => o.priority === "high").length,
           medium: optimizations.filter((o) => o.priority === "medium").length,
           low: optimizations.filter((o) => o.priority === "low").length,

--- a/src/server/api/routers/nodes.ts
+++ b/src/server/api/routers/nodes.ts
@@ -14,21 +14,19 @@ export const nodesRouter = createTRPCRouter({
    */
   list: publicProcedure
     .input(
-      z.object({
-        status: z.enum(["all", "active", "inactive"]).default("all"),
-        version: z.string().optional(),
-        search: z.string().optional(),
-        limit: z.number().min(1).max(100).default(50),
-        offset: z.number().min(0).default(0),
-        orderBy: z.enum([
-          "lastSeen",
-          "firstSeen",
-          "address",
-          "version",
-          "isActive",
-        ]).default("lastSeen"),
-        order: z.enum(["asc", "desc"]).default("desc"),
-      }).optional()
+      z
+        .object({
+          status: z.enum(["all", "active", "inactive"]).default("all"),
+          version: z.string().optional(),
+          search: z.string().optional(),
+          limit: z.number().min(1).max(100).default(50),
+          offset: z.number().min(0).default(0),
+          orderBy: z
+            .enum(["lastSeen", "firstSeen", "address", "version", "isActive"])
+            .default("lastSeen"),
+          order: z.enum(["asc", "desc"]).default("desc"),
+        })
+        .optional(),
     )
     .query(async ({ ctx, input }) => {
       const {
@@ -45,7 +43,10 @@ export const nodesRouter = createTRPCRouter({
       const where: {
         isActive?: boolean;
         version?: string;
-        OR?: Array<{ address?: { contains: string }; pubkey?: { contains: string } }>;
+        OR?: Array<{
+          address?: { contains: string };
+          pubkey?: { contains: string };
+        }>;
       } = {};
 
       if (status === "active") where.isActive = true;
@@ -70,7 +71,9 @@ export const nodesRouter = createTRPCRouter({
             },
           },
         }),
-        ctx.db.node.count({ where: Object.keys(where).length > 0 ? where : undefined }),
+        ctx.db.node.count({
+          where: Object.keys(where).length > 0 ? where : undefined,
+        }),
       ]);
 
       return {
@@ -104,21 +107,19 @@ export const nodesRouter = createTRPCRouter({
    */
   listWithMetrics: publicProcedure
     .input(
-      z.object({
-        status: z.enum(["all", "active", "inactive"]).default("all"),
-        version: z.string().optional(),
-        search: z.string().optional(),
-        limit: z.number().min(1).max(100).default(50),
-        offset: z.number().min(0).default(0),
-        orderBy: z.enum([
-          "lastSeen",
-          "firstSeen",
-          "address",
-          "version",
-          "isActive",
-        ]).default("lastSeen"),
-        order: z.enum(["asc", "desc"]).default("desc"),
-      }).optional()
+      z
+        .object({
+          status: z.enum(["all", "active", "inactive"]).default("all"),
+          version: z.string().optional(),
+          search: z.string().optional(),
+          limit: z.number().min(1).max(100).default(50),
+          offset: z.number().min(0).default(0),
+          orderBy: z
+            .enum(["lastSeen", "firstSeen", "address", "version", "isActive"])
+            .default("lastSeen"),
+          order: z.enum(["asc", "desc"]).default("desc"),
+        })
+        .optional(),
     )
     .query(async ({ ctx, input }) => {
       const {
@@ -135,7 +136,10 @@ export const nodesRouter = createTRPCRouter({
       const where: {
         isActive?: boolean;
         version?: string;
-        OR?: Array<{ address?: { contains: string }; pubkey?: { contains: string } }>;
+        OR?: Array<{
+          address?: { contains: string };
+          pubkey?: { contains: string };
+        }>;
       } = {};
 
       if (status === "active") where.isActive = true;
@@ -162,14 +166,16 @@ export const nodesRouter = createTRPCRouter({
 
       // Get latest metrics for these nodes
       const nodeIds = nodes.map((n) => n.id);
-      const latestMetrics = await ctx.db.$queryRaw<Array<{
-        node_id: number;
-        cpu_percent: number;
-        ram_used: bigint;
-        ram_total: bigint;
-        file_size: bigint;
-        uptime: number;
-      }>>`
+      const latestMetrics = await ctx.db.$queryRaw<
+        Array<{
+          node_id: number;
+          cpu_percent: number;
+          ram_used: bigint;
+          ram_total: bigint;
+          file_size: bigint;
+          uptime: number;
+        }>
+      >`
         SELECT DISTINCT ON (node_id)
           node_id,
           cpu_percent,
@@ -190,13 +196,14 @@ export const nodesRouter = createTRPCRouter({
             cpuPercent: m.cpu_percent,
             ramUsed: m.ram_used,
             ramTotal: m.ram_total,
-            ramPercent: m.ram_total > BigInt(0)
-              ? Number((m.ram_used * BigInt(100)) / m.ram_total)
-              : 0,
+            ramPercent:
+              m.ram_total > BigInt(0)
+                ? Number((m.ram_used * BigInt(100)) / m.ram_total)
+                : 0,
             fileSize: m.file_size,
             uptime: m.uptime,
           },
-        ])
+        ]),
       );
 
       // Combine nodes with their metrics
@@ -217,52 +224,48 @@ export const nodesRouter = createTRPCRouter({
   /**
    * Get a single node by ID
    */
-  byId: publicProcedure
-    .input(z.number())
-    .query(async ({ ctx, input }) => {
-      const node = await ctx.db.node.findUnique({
-        where: { id: input },
-        include: {
-          _count: {
-            select: { metrics: true, peers: true },
-          },
+  byId: publicProcedure.input(z.number()).query(async ({ ctx, input }) => {
+    const node = await ctx.db.node.findUnique({
+      where: { id: input },
+      include: {
+        _count: {
+          select: { metrics: true, peers: true },
         },
+      },
+    });
+
+    if (!node) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: `Node with ID ${input} not found`,
       });
+    }
 
-      if (!node) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: `Node with ID ${input} not found`,
-        });
-      }
-
-      return node;
-    }),
+    return node;
+  }),
 
   /**
    * Get a single node by address
    */
-  byAddress: publicProcedure
-    .input(z.string())
-    .query(async ({ ctx, input }) => {
-      const node = await ctx.db.node.findUnique({
-        where: { address: input },
-        include: {
-          _count: {
-            select: { metrics: true, peers: true },
-          },
+  byAddress: publicProcedure.input(z.string()).query(async ({ ctx, input }) => {
+    const node = await ctx.db.node.findUnique({
+      where: { address: input },
+      include: {
+        _count: {
+          select: { metrics: true, peers: true },
         },
+      },
+    });
+
+    if (!node) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: `Node with address ${input} not found`,
       });
+    }
 
-      if (!node) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: `Node with address ${input} not found`,
-        });
-      }
-
-      return node;
-    }),
+    return node;
+  }),
 
   /**
    * Get metrics history for a node
@@ -273,7 +276,7 @@ export const nodesRouter = createTRPCRouter({
         nodeId: z.number(),
         range: z.enum(["1h", "24h", "7d", "30d"]).default("24h"),
         aggregation: z.enum(["raw", "hourly", "daily"]).default("hourly"),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const { nodeId, range, aggregation } = input;
@@ -312,13 +315,14 @@ export const nodesRouter = createTRPCRouter({
         sample_count: bigint;
       };
 
-      const metrics = aggregation === "hourly"
-        ? await ctx.db.$queryRaw<AggregatedMetric[]>`
+      const metrics =
+        aggregation === "hourly"
+          ? await ctx.db.$queryRaw<AggregatedMetric[]>`
             SELECT bucket, avg_cpu, avg_ram_percent, max_uptime, max_file_size, sample_count
             FROM node_metrics_hourly
             WHERE node_id = ${nodeId} AND bucket >= ${startTime}
             ORDER BY bucket ASC`
-        : await ctx.db.$queryRaw<AggregatedMetric[]>`
+          : await ctx.db.$queryRaw<AggregatedMetric[]>`
             SELECT bucket, avg_cpu, avg_ram_percent, max_uptime, max_file_size, sample_count
             FROM node_metrics_daily
             WHERE node_id = ${nodeId} AND bucket >= ${startTime}
@@ -344,26 +348,26 @@ export const nodesRouter = createTRPCRouter({
   /**
    * Get peers for a node
    */
-  peers: publicProcedure
-    .input(z.number())
-    .query(async ({ ctx, input }) => {
-      const peers = await ctx.db.nodePeer.findMany({
-        where: { nodeId: input },
-        include: {
-          peerNode: {
-            select: {
-              id: true,
-              address: true,
-              version: true,
-              isActive: true,
-            },
+  peers: publicProcedure.input(z.number()).query(async ({ ctx, input }) => {
+    const peers = await ctx.db.nodePeer.findMany({
+      where: { nodeId: input },
+      include: {
+        peerNode: {
+          select: {
+            id: true,
+            address: true,
+            version: true,
+            isActive: true,
           },
         },
-        orderBy: { lastSeenAt: "desc" },
-      });
+      },
+      orderBy: { lastSeenAt: "desc" },
+    });
 
-      return peers;
-    }),
+    // NodePeer.id is BigInt in the DB; coerce to number to keep the API
+    // response contract (and avoid leaking bigint to clients).
+    return peers.map((p) => ({ ...p, id: Number(p.id) }));
+  }),
 
   /**
    * Get summary stats for all active nodes
@@ -375,12 +379,14 @@ export const nodesRouter = createTRPCRouter({
     ]);
 
     // Get latest metrics for all active nodes
-    const latestMetrics = await ctx.db.$queryRaw<Array<{
-      total_storage: bigint;
-      avg_cpu: number;
-      avg_ram_percent: number;
-      avg_uptime: number;
-    }>>`
+    const latestMetrics = await ctx.db.$queryRaw<
+      Array<{
+        total_storage: bigint;
+        avg_cpu: number;
+        avg_ram_percent: number;
+        avg_uptime: number;
+      }>
+    >`
       SELECT
         COALESCE(SUM(file_size), 0) as total_storage,
         COALESCE(AVG(cpu_percent), 0) as avg_cpu,
@@ -419,7 +425,7 @@ export const nodesRouter = createTRPCRouter({
         metric: z.enum(["uptime", "cpu", "ram", "storage"]).default("uptime"),
         order: z.enum(["top", "bottom"]).default("top"),
         limit: z.number().min(1).max(20).default(5),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const { metric, order, limit } = input;
@@ -442,8 +448,9 @@ export const nodesRouter = createTRPCRouter({
 
       if (metric === "uptime") {
         // Higher uptime is better: top = DESC, bottom = ASC
-        result = order === "top"
-          ? await ctx.db.$queryRaw<LeaderboardRow[]>`
+        result =
+          order === "top"
+            ? await ctx.db.$queryRaw<LeaderboardRow[]>`
               WITH latest_metrics AS (
                 SELECT DISTINCT ON (nm.node_id) nm.node_id, nm.cpu_percent,
                   CASE WHEN nm.ram_total > 0 THEN (nm.ram_used::float / nm.ram_total * 100) ELSE 0 END as ram_percent,
@@ -455,7 +462,7 @@ export const nodesRouter = createTRPCRouter({
               FROM nodes n JOIN latest_metrics lm ON lm.node_id = n.id
               WHERE n.is_active = true
               ORDER BY lm.uptime DESC NULLS LAST LIMIT ${limit}`
-          : await ctx.db.$queryRaw<LeaderboardRow[]>`
+            : await ctx.db.$queryRaw<LeaderboardRow[]>`
               WITH latest_metrics AS (
                 SELECT DISTINCT ON (nm.node_id) nm.node_id, nm.cpu_percent,
                   CASE WHEN nm.ram_total > 0 THEN (nm.ram_used::float / nm.ram_total * 100) ELSE 0 END as ram_percent,
@@ -469,8 +476,9 @@ export const nodesRouter = createTRPCRouter({
               ORDER BY lm.uptime ASC NULLS LAST LIMIT ${limit}`;
       } else if (metric === "cpu") {
         // Lower CPU is better: top = ASC, bottom = DESC
-        result = order === "top"
-          ? await ctx.db.$queryRaw<LeaderboardRow[]>`
+        result =
+          order === "top"
+            ? await ctx.db.$queryRaw<LeaderboardRow[]>`
               WITH latest_metrics AS (
                 SELECT DISTINCT ON (nm.node_id) nm.node_id, nm.cpu_percent,
                   CASE WHEN nm.ram_total > 0 THEN (nm.ram_used::float / nm.ram_total * 100) ELSE 0 END as ram_percent,
@@ -482,7 +490,7 @@ export const nodesRouter = createTRPCRouter({
               FROM nodes n JOIN latest_metrics lm ON lm.node_id = n.id
               WHERE n.is_active = true
               ORDER BY lm.cpu_percent ASC NULLS LAST LIMIT ${limit}`
-          : await ctx.db.$queryRaw<LeaderboardRow[]>`
+            : await ctx.db.$queryRaw<LeaderboardRow[]>`
               WITH latest_metrics AS (
                 SELECT DISTINCT ON (nm.node_id) nm.node_id, nm.cpu_percent,
                   CASE WHEN nm.ram_total > 0 THEN (nm.ram_used::float / nm.ram_total * 100) ELSE 0 END as ram_percent,
@@ -496,8 +504,9 @@ export const nodesRouter = createTRPCRouter({
               ORDER BY lm.cpu_percent DESC NULLS LAST LIMIT ${limit}`;
       } else if (metric === "ram") {
         // Lower RAM is better: top = ASC, bottom = DESC
-        result = order === "top"
-          ? await ctx.db.$queryRaw<LeaderboardRow[]>`
+        result =
+          order === "top"
+            ? await ctx.db.$queryRaw<LeaderboardRow[]>`
               WITH latest_metrics AS (
                 SELECT DISTINCT ON (nm.node_id) nm.node_id, nm.cpu_percent,
                   CASE WHEN nm.ram_total > 0 THEN (nm.ram_used::float / nm.ram_total * 100) ELSE 0 END as ram_percent,
@@ -509,7 +518,7 @@ export const nodesRouter = createTRPCRouter({
               FROM nodes n JOIN latest_metrics lm ON lm.node_id = n.id
               WHERE n.is_active = true
               ORDER BY lm.ram_percent ASC NULLS LAST LIMIT ${limit}`
-          : await ctx.db.$queryRaw<LeaderboardRow[]>`
+            : await ctx.db.$queryRaw<LeaderboardRow[]>`
               WITH latest_metrics AS (
                 SELECT DISTINCT ON (nm.node_id) nm.node_id, nm.cpu_percent,
                   CASE WHEN nm.ram_total > 0 THEN (nm.ram_used::float / nm.ram_total * 100) ELSE 0 END as ram_percent,
@@ -523,8 +532,9 @@ export const nodesRouter = createTRPCRouter({
               ORDER BY lm.ram_percent DESC NULLS LAST LIMIT ${limit}`;
       } else {
         // storage: Higher is better: top = DESC, bottom = ASC
-        result = order === "top"
-          ? await ctx.db.$queryRaw<LeaderboardRow[]>`
+        result =
+          order === "top"
+            ? await ctx.db.$queryRaw<LeaderboardRow[]>`
               WITH latest_metrics AS (
                 SELECT DISTINCT ON (nm.node_id) nm.node_id, nm.cpu_percent,
                   CASE WHEN nm.ram_total > 0 THEN (nm.ram_used::float / nm.ram_total * 100) ELSE 0 END as ram_percent,
@@ -536,7 +546,7 @@ export const nodesRouter = createTRPCRouter({
               FROM nodes n JOIN latest_metrics lm ON lm.node_id = n.id
               WHERE n.is_active = true
               ORDER BY lm.file_size DESC NULLS LAST LIMIT ${limit}`
-          : await ctx.db.$queryRaw<LeaderboardRow[]>`
+            : await ctx.db.$queryRaw<LeaderboardRow[]>`
               WITH latest_metrics AS (
                 SELECT DISTINCT ON (nm.node_id) nm.node_id, nm.cpu_percent,
                   CASE WHEN nm.ram_total > 0 THEN (nm.ram_used::float / nm.ram_total * 100) ELSE 0 END as ram_percent,
@@ -571,7 +581,7 @@ export const nodesRouter = createTRPCRouter({
       z.object({
         nodeId: z.number(),
         range: z.enum(["7d", "30d", "90d"]).default("7d"),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const { nodeId, range } = input;
@@ -593,13 +603,14 @@ export const nodesRouter = createTRPCRouter({
       };
 
       // Use hourly aggregates for 7d, daily for longer ranges
-      const metrics = range === "7d"
-        ? await ctx.db.$queryRaw<MetricsHistoryRow[]>`
+      const metrics =
+        range === "7d"
+          ? await ctx.db.$queryRaw<MetricsHistoryRow[]>`
             SELECT bucket, avg_cpu, avg_ram_percent
             FROM node_metrics_hourly
             WHERE node_id = ${nodeId} AND bucket >= ${startTime}
             ORDER BY bucket ASC`
-        : await ctx.db.$queryRaw<MetricsHistoryRow[]>`
+          : await ctx.db.$queryRaw<MetricsHistoryRow[]>`
             SELECT bucket, avg_cpu, avg_ram_percent
             FROM node_metrics_daily
             WHERE node_id = ${nodeId} AND bucket >= ${startTime}
@@ -620,7 +631,7 @@ export const nodesRouter = createTRPCRouter({
       z.object({
         nodeId: z.number(),
         limit: z.number().min(1).max(100).default(20),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const { nodeId, limit } = input;
@@ -642,27 +653,25 @@ export const nodesRouter = createTRPCRouter({
   /**
    * #164: Get node by pubkey
    */
-  byPubkey: publicProcedure
-    .input(z.string())
-    .query(async ({ ctx, input }) => {
-      const node = await ctx.db.node.findUnique({
-        where: { pubkey: input },
-        include: {
-          _count: {
-            select: { metrics: true, peers: true, addressChanges: true },
-          },
+  byPubkey: publicProcedure.input(z.string()).query(async ({ ctx, input }) => {
+    const node = await ctx.db.node.findUnique({
+      where: { pubkey: input },
+      include: {
+        _count: {
+          select: { metrics: true, peers: true, addressChanges: true },
         },
+      },
+    });
+
+    if (!node) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: `Node with pubkey ${input} not found`,
       });
+    }
 
-      if (!node) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: `Node with pubkey ${input} not found`,
-        });
-      }
-
-      return node;
-    }),
+    return node;
+  }),
 
   /**
    * #169: Get recent IP address changes across the network
@@ -672,7 +681,7 @@ export const nodesRouter = createTRPCRouter({
       z.object({
         limit: z.number().min(1).max(100).default(20),
         range: z.enum(["24h", "7d", "30d"]).default("7d"),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const { limit, range } = input;


### PR DESCRIPTION
## Problem

`node_peers_id_seq` hit the **int4 max (2147483647)** — `max(id)` on prod is already **2,143,726,650**. Every `nodePeer.upsert()` ON CONFLICT burns a sequence value (not just inserts), so int4 was exhausted. The collector's peer-update cycles now abort with `PostgresError 2200H`. No low-id headroom exists, so a sequence reset won't help — the column must be widened.

## Fix

- **schema**: `NodePeer.id` `Int` → `BigInt` (pure surrogate; nothing FKs to it).
- **migration** `20260529030500_node_peers_id_bigint`: `ALTER COLUMN id TYPE bigint` + `ALTER SEQUENCE node_peers_id_seq AS bigint` (Postgres won't widen the sequence on its own, and the sequence is what's maxed). Note: rewrites the table under a brief ACCESS EXCLUSIVE lock.
- **code**: coerce the sites that surface `id` as a `number` (`peerId` fallback; the per-node peers endpoint return) with `Number()`. superjson already handles bigint over the wire; these keep the API contract. Monolith + pulse-api.

## Testing
307 + 24 tests pass; both typechecks clean. Compiler-verified every coercion site.

## Deploy ordering (manual, this session)
Deploy web (BigInt client reads int4 fine) → apply migration → update the collector's `~/pnode-pulse-src` snapshot schema + restart (its Int client would otherwise throw on new bigint ids). Collector productionization remains a separate follow-up.