### PR TITLE
docs: sync deploy docs to single-container model + correct VPS IP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,26 +214,25 @@ curl -X POST http://<ip-address>:6000/rpc \
 
 ## Deployment
 
-**VPS**: 176.222.53.185 (rectorspace.com)
+**VPS**: 151.245.137.75 (rectorspace.com)
 **User**: pnodepulse
 **Domain**: pulse.rectorspace.com
 
-| Service     | Port |
-| ----------- | ---- |
-| Web (Blue)  | 7000 |
-| Web (Green) | 7001 |
-| Staging     | 7002 |
-| PostgreSQL  | 5434 |
-| Redis       | 6381 |
+| Service          | Port          |
+| ---------------- | ------------- |
+| Web (Production) | 7001          |
+| Staging          | 7002          |
+| PostgreSQL       | internal only |
+| Redis            | internal only |
 
 ### Push-to-Deploy Workflow
 
 **Automated deployment** triggers on every push to main/dev branches:
 
-| Branch | Environment             | Port      | URL                           |
-| ------ | ----------------------- | --------- | ----------------------------- |
-| `dev`  | Staging                 | 7002      | staging.pulse.rectorspace.com |
-| `main` | Production (Blue/Green) | 7000/7001 | pulse.rectorspace.com         |
+| Branch | Environment                   | Port | URL                           |
+| ------ | ----------------------------- | ---- | ----------------------------- |
+| `dev`  | Staging                       | 7002 | staging.pulse.rectorspace.com |
+| `main` | Production (single container) | 7001 | pulse.rectorspace.com         |
 
 #### Deployment Flow
 
@@ -250,15 +249,13 @@ curl -X POST http://<ip-address>:6000/rpc \
 
 1. Push to `main` branch
 2. GitHub Actions builds Docker image
-3. Pushes image to GHCR with `:latest` tag
+3. Pushes image to GHCR with `:latest` tag (plus a `:prod-<sha>` tag for rollback)
 4. SSH to VPS, pulls new image
-5. Runs blue/green deployment script:
-   - Detects active environment (blue/green)
-   - Starts inactive environment with new image
-   - Waits for healthcheck to pass
-   - Manual/automated switch to new environment
-   - Stops old environment
-6. Zero-downtime deployment
+5. Runs `scripts/deploy.sh`:
+   - `docker compose pull green` to fetch the new image
+   - `docker compose up -d --no-deps green` to recreate ONLY the `green` web container (`--no-deps` leaves postgres/redis/collector untouched)
+   - Health-gates the new container before considering the deploy successful
+6. Single-container deploy with a brief ~5-15s restart blip (no longer zero-downtime); nginx points permanently at `localhost:7001`
 
 #### Required GitHub Secrets
 
@@ -266,7 +263,7 @@ Configure these in repository settings (Settings → Secrets and variables → A
 
 | Secret              | Value             | Description                           |
 | ------------------- | ----------------- | ------------------------------------- |
-| `VPS_SSH_KEY`       | Private SSH key   | SSH key for pnodepulse@176.222.53.185 |
+| `VPS_SSH_KEY`       | Private SSH key   | SSH key for pnodepulse@151.245.137.75 |
 | `POSTGRES_PASSWORD` | Database password | PostgreSQL password for production    |
 
 #### Deployment Commands
@@ -278,29 +275,29 @@ cd ~/pnode-pulse
 docker compose pull staging
 docker compose up -d staging
 
-# Manual blue/green deployment
+# Manual production deployment (single container)
 ssh pnodepulse
 cd ~/pnode-pulse
-bash scripts/blue-green-deploy.sh
+bash scripts/deploy.sh
 
 # Check deployment status
 docker compose ps
-docker compose logs -f blue green staging
+docker compose logs -f green staging
 
 # Rollback (if needed)
-# Simply switch back to previous environment
-docker compose up -d blue  # or green
+# Re-deploy a known-good image by its :prod-<sha> tag, then recreate green
+docker compose pull green
+docker compose up -d --no-deps green
 ```
 
 #### Health Checks
 
 All services have health endpoints for monitoring:
 
-| Endpoint | URL                              | Checks            |
-| -------- | -------------------------------- | ----------------- |
-| Staging  | http://localhost:7002/api/health | DB, Redis, uptime |
-| Blue     | http://localhost:7000/api/health | DB, Redis, uptime |
-| Green    | http://localhost:7001/api/health | DB, Redis, uptime |
+| Endpoint           | URL                              | Checks            |
+| ------------------ | -------------------------------- | ----------------- |
+| Staging            | http://localhost:7002/api/health | DB, Redis, uptime |
+| Green (Production) | http://localhost:7001/api/health | DB, Redis, uptime |
 
 Health check response:
 
@@ -330,11 +327,11 @@ server {
   }
 }
 
-# Production (point to active blue/green port)
+# Production (single container, green)
 server {
   server_name pulse.rectorspace.com;
   location / {
-    proxy_pass http://localhost:7000;  # or 7001 for green
+    proxy_pass http://localhost:7001;  # green container (permanent, no switching)
   }
 }
 ```
@@ -362,8 +359,8 @@ docker compose ps
 # Run database migrations
 docker compose exec postgres psql -U pnodepulse -d pnodepulse -f /path/to/migration.sql
 
-# Start initial deployment (blue)
-docker compose up -d blue
+# Start initial deployment (green, single production container)
+docker compose up -d green
 ```
 
 ## Project Structure
@@ -718,9 +715,9 @@ console.log(pods);
 **Deployment Infrastructure** ✅ COMPLETE
 
 - [x] GitHub Actions workflow for staging (dev branch)
-- [x] GitHub Actions workflow for production (main branch with blue/green)
+- [x] GitHub Actions workflow for production (main branch, single-container deploy)
 - [x] Docker Compose configuration with multi-environment support
-- [x] Blue/green deployment script with zero-downtime
+- [x] Single-container deploy script (`scripts/deploy.sh`) with `--no-deps` + health-gate (brief restart blip)
 - [x] Health check endpoints for all services
 - [x] VPS setup complete (user, ports, SSH config)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,12 +37,12 @@ pNode Pulse is a real-time analytics platform for Xandeum's pNode network. It ag
 
 ### Target Users
 
-| User Type | Primary Needs |
-|-----------|---------------|
+| User Type           | Primary Needs                                            |
+| ------------------- | -------------------------------------------------------- |
 | **pNode Operators** | Real-time monitoring, performance optimization, alerting |
-| **Developers** | API access, integration tools, network statistics |
-| **Community** | Network health visibility, trust verification |
-| **Xandeum Team** | Ecosystem analytics, adoption metrics |
+| **Developers**      | API access, integration tools, network statistics        |
+| **Community**       | Network health visibility, trust verification            |
+| **Xandeum Team**    | Ecosystem analytics, adoption metrics                    |
 
 ---
 
@@ -106,20 +106,20 @@ Returns comprehensive system metrics. **Note**: Actual response structure is fla
 }
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `active_streams` | number | Active network streams |
-| `cpu_percent` | number | CPU usage percentage |
-| `current_index` | number | Current page index |
-| `file_size` | number | Storage file size (bytes) |
-| `last_updated` | number | Unix timestamp of last update |
-| `packets_received` | number | Total packets received |
-| `packets_sent` | number | Total packets sent |
-| `ram_total` | number | Total RAM (bytes) |
-| `ram_used` | number | RAM in use (bytes) |
-| `total_bytes` | number | Total bytes processed |
-| `total_pages` | number | Total pages in storage |
-| `uptime` | number | Uptime in seconds |
+| Field              | Type   | Description                   |
+| ------------------ | ------ | ----------------------------- |
+| `active_streams`   | number | Active network streams        |
+| `cpu_percent`      | number | CPU usage percentage          |
+| `current_index`    | number | Current page index            |
+| `file_size`        | number | Storage file size (bytes)     |
+| `last_updated`     | number | Unix timestamp of last update |
+| `packets_received` | number | Total packets received        |
+| `packets_sent`     | number | Total packets sent            |
+| `ram_total`        | number | Total RAM (bytes)             |
+| `ram_used`         | number | RAM in use (bytes)            |
+| `total_bytes`      | number | Total bytes processed         |
+| `total_pages`      | number | Total pages in storage        |
+| `uptime`           | number | Uptime in seconds             |
 
 #### 3. `get-pods`
 
@@ -148,13 +148,13 @@ Returns list of known peer pNodes. **Note**: Includes `pubkey` field not documen
 }
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `address` | string | IP:port of peer pNode (gossip port 9001) |
-| `last_seen_timestamp` | number | Unix timestamp of last contact |
-| `pubkey` | string \| null | pNode public key (Solana format) |
-| `version` | string | Software version ("unknown" if unavailable) |
-| `total_count` | number | Total known pNodes |
+| Field                 | Type           | Description                                 |
+| --------------------- | -------------- | ------------------------------------------- |
+| `address`             | string         | IP:port of peer pNode (gossip port 9001)    |
+| `last_seen_timestamp` | number         | Unix timestamp of last contact              |
+| `pubkey`              | string \| null | pNode public key (Solana format)            |
+| `version`             | string         | Software version ("unknown" if unavailable) |
+| `total_count`         | number         | Total known pNodes                          |
 
 ### Known Public pNodes (pRPC Port 6000 Open)
 
@@ -174,17 +174,18 @@ As of 2025-12-07, these pNodes have public pRPC access:
 
 ### Network Ports Reference
 
-| Port | Service | Access |
-|------|---------|--------|
-| 6000 | pRPC API | Configurable (localhost or public) |
-| 9001 | Gossip Protocol | Public (peer discovery) |
-| 5000 | Atlas Server | Internal |
-| 3000 | XandMiner GUI | Localhost |
-| 80 | Stats Dashboard | Localhost |
+| Port | Service         | Access                             |
+| ---- | --------------- | ---------------------------------- |
+| 6000 | pRPC API        | Configurable (localhost or public) |
+| 9001 | Gossip Protocol | Public (peer discovery)            |
+| 5000 | Atlas Server    | Internal                           |
+| 3000 | XandMiner GUI   | Localhost                          |
+| 80   | Stats Dashboard | Localhost                          |
 
 ### Upcoming API Features
 
 Per Xandeum team (Discord, 2025-12-07):
+
 - **Detailed call for ALL pNodes** - Returns aggregated data for entire network
 - **Paging statistics** - v0.7 Heidelberg release
 
@@ -194,17 +195,17 @@ Per Xandeum team (Discord, 2025-12-07):
 
 ### Tech Stack
 
-| Layer | Technology | Rationale |
-|-------|------------|-----------|
-| **Frontend** | Next.js 14 (App Router) | SSR, API routes, modern React |
-| **Styling** | Tailwind CSS | Utility-first, rapid development |
-| **Charts** | Recharts / Tremor | React-native, accessible |
-| **Backend** | Node.js + tRPC | Type-safe API, integrated with Next.js |
-| **Database** | PostgreSQL | Relational data, reliability |
-| **Time-Series** | TimescaleDB | Optimized for metrics storage |
-| **Cache** | Redis | Real-time data, pub/sub |
-| **Queue** | BullMQ | Background job processing |
-| **Deployment** | Docker Compose | Reproducible, isolated |
+| Layer           | Technology              | Rationale                              |
+| --------------- | ----------------------- | -------------------------------------- |
+| **Frontend**    | Next.js 14 (App Router) | SSR, API routes, modern React          |
+| **Styling**     | Tailwind CSS            | Utility-first, rapid development       |
+| **Charts**      | Recharts / Tremor       | React-native, accessible               |
+| **Backend**     | Node.js + tRPC          | Type-safe API, integrated with Next.js |
+| **Database**    | PostgreSQL              | Relational data, reliability           |
+| **Time-Series** | TimescaleDB             | Optimized for metrics storage          |
+| **Cache**       | Redis                   | Real-time data, pub/sub                |
+| **Queue**       | BullMQ                  | Background job processing              |
+| **Deployment**  | Docker Compose          | Reproducible, isolated                 |
 
 ### System Architecture
 
@@ -259,15 +260,15 @@ Per Xandeum team (Discord, 2025-12-07):
 ### Deployment Architecture
 
 **Domain**: `pulse.rectorspace.com`
-**VPS**: 176.222.53.185 (rectorspace.com)
+**VPS**: 151.245.137.75 (rectorspace.com)
 
-| Service | Port | Container Name |
-|---------|------|----------------|
-| Web (Blue) | 7000 | pnode-pulse-web-blue |
+| Service     | Port | Container Name        |
+| ----------- | ---- | --------------------- |
+| Web (Blue)  | 7000 | pnode-pulse-web-blue  |
 | Web (Green) | 7001 | pnode-pulse-web-green |
-| Staging | 7002 | pnode-pulse-staging |
-| PostgreSQL | 5434 | pnode-pulse-postgres |
-| Redis | 6381 | pnode-pulse-redis |
+| Staging     | 7002 | pnode-pulse-staging   |
+| PostgreSQL  | 5434 | pnode-pulse-postgres  |
+| Redis       | 6381 | pnode-pulse-redis     |
 
 ---
 
@@ -281,79 +282,79 @@ Per Xandeum team (Discord, 2025-12-07):
 
 #### Epic 1.1: Project Setup & Infrastructure
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 1.1.1 | Initialize Next.js 14 project with TypeScript | P0 | S |
-| 1.1.2 | Configure Tailwind CSS and design tokens | P0 | S |
-| 1.1.3 | Set up ESLint, Prettier, Husky | P0 | S |
-| 1.1.4 | Create Docker Compose for local development | P0 | M |
-| 1.1.5 | Set up PostgreSQL + TimescaleDB schema | P0 | M |
-| 1.1.6 | Configure Redis for caching | P1 | S |
-| 1.1.7 | Set up CI/CD pipeline (GitHub Actions) | P1 | M |
+| ID    | Story                                         | Priority | Estimate |
+| ----- | --------------------------------------------- | -------- | -------- |
+| 1.1.1 | Initialize Next.js 14 project with TypeScript | P0       | S        |
+| 1.1.2 | Configure Tailwind CSS and design tokens      | P0       | S        |
+| 1.1.3 | Set up ESLint, Prettier, Husky                | P0       | S        |
+| 1.1.4 | Create Docker Compose for local development   | P0       | M        |
+| 1.1.5 | Set up PostgreSQL + TimescaleDB schema        | P0       | M        |
+| 1.1.6 | Configure Redis for caching                   | P1       | S        |
+| 1.1.7 | Set up CI/CD pipeline (GitHub Actions)        | P1       | M        |
 
 #### Epic 1.2: pRPC Client Library
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 1.2.1 | Create type-safe pRPC client | P0 | M |
-| 1.2.2 | Implement `get-version` method | P0 | S |
-| 1.2.3 | Implement `get-stats` method | P0 | S |
-| 1.2.4 | Implement `get-pods` method | P0 | S |
-| 1.2.5 | Add retry logic and error handling | P0 | M |
-| 1.2.6 | Add request timeout configuration | P1 | S |
-| 1.2.7 | Add connection pooling | P2 | M |
-| 1.2.8 | Write comprehensive unit tests | P0 | M |
+| ID    | Story                              | Priority | Estimate |
+| ----- | ---------------------------------- | -------- | -------- |
+| 1.2.1 | Create type-safe pRPC client       | P0       | M        |
+| 1.2.2 | Implement `get-version` method     | P0       | S        |
+| 1.2.3 | Implement `get-stats` method       | P0       | S        |
+| 1.2.4 | Implement `get-pods` method        | P0       | S        |
+| 1.2.5 | Add retry logic and error handling | P0       | M        |
+| 1.2.6 | Add request timeout configuration  | P1       | S        |
+| 1.2.7 | Add connection pooling             | P2       | M        |
+| 1.2.8 | Write comprehensive unit tests     | P0       | M        |
 
 #### Epic 1.3: Data Collection Engine
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 1.3.1 | Create scheduled data collection worker | P0 | M |
-| 1.3.2 | Implement node discovery via `get-pods` | P0 | M |
-| 1.3.3 | Parallel data collection from multiple nodes | P0 | L |
-| 1.3.4 | Data validation and normalization | P0 | M |
-| 1.3.5 | Store metrics in TimescaleDB | P0 | M |
-| 1.3.6 | Cache latest data in Redis | P1 | S |
-| 1.3.7 | Handle node unavailability gracefully | P0 | M |
-| 1.3.8 | Implement collection health monitoring | P1 | M |
+| ID    | Story                                        | Priority | Estimate |
+| ----- | -------------------------------------------- | -------- | -------- |
+| 1.3.1 | Create scheduled data collection worker      | P0       | M        |
+| 1.3.2 | Implement node discovery via `get-pods`      | P0       | M        |
+| 1.3.3 | Parallel data collection from multiple nodes | P0       | L        |
+| 1.3.4 | Data validation and normalization            | P0       | M        |
+| 1.3.5 | Store metrics in TimescaleDB                 | P0       | M        |
+| 1.3.6 | Cache latest data in Redis                   | P1       | S        |
+| 1.3.7 | Handle node unavailability gracefully        | P0       | M        |
+| 1.3.8 | Implement collection health monitoring       | P1       | M        |
 
 #### Epic 1.4: Database Schema & Models
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 1.4.1 | Design node registry table | P0 | S |
-| 1.4.2 | Design metrics hypertable (TimescaleDB) | P0 | M |
-| 1.4.3 | Design network snapshots table | P1 | S |
-| 1.4.4 | Create database migrations | P0 | M |
-| 1.4.5 | Implement data retention policies | P1 | M |
-| 1.4.6 | Create database indexes for queries | P1 | S |
+| ID    | Story                                   | Priority | Estimate |
+| ----- | --------------------------------------- | -------- | -------- |
+| 1.4.1 | Design node registry table              | P0       | S        |
+| 1.4.2 | Design metrics hypertable (TimescaleDB) | P0       | M        |
+| 1.4.3 | Design network snapshots table          | P1       | S        |
+| 1.4.4 | Create database migrations              | P0       | M        |
+| 1.4.5 | Implement data retention policies       | P1       | M        |
+| 1.4.6 | Create database indexes for queries     | P1       | S        |
 
 #### Epic 1.5: API Layer
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 1.5.1 | Set up tRPC with Next.js | P0 | M |
-| 1.5.2 | Create node list endpoint | P0 | S |
-| 1.5.3 | Create node detail endpoint | P0 | S |
-| 1.5.4 | Create network overview endpoint | P0 | M |
-| 1.5.5 | Create metrics history endpoint | P0 | M |
-| 1.5.6 | Add WebSocket support for real-time updates | P1 | L |
-| 1.5.7 | Implement API rate limiting | P2 | M |
+| ID    | Story                                       | Priority | Estimate |
+| ----- | ------------------------------------------- | -------- | -------- |
+| 1.5.1 | Set up tRPC with Next.js                    | P0       | M        |
+| 1.5.2 | Create node list endpoint                   | P0       | S        |
+| 1.5.3 | Create node detail endpoint                 | P0       | S        |
+| 1.5.4 | Create network overview endpoint            | P0       | M        |
+| 1.5.5 | Create metrics history endpoint             | P0       | M        |
+| 1.5.6 | Add WebSocket support for real-time updates | P1       | L        |
+| 1.5.7 | Implement API rate limiting                 | P2       | M        |
 
 #### Epic 1.6: Basic Dashboard UI
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 1.6.1 | Create app layout and navigation | P0 | M |
-| 1.6.2 | Build network overview page | P0 | L |
-| 1.6.3 | Build node list page with sorting/filtering | P0 | L |
-| 1.6.4 | Build node detail page | P0 | L |
-| 1.6.5 | Create metric cards component | P0 | M |
-| 1.6.6 | Create line chart component | P0 | M |
-| 1.6.7 | Add real-time update indicators | P1 | M |
-| 1.6.8 | Implement responsive design | P1 | M |
-| 1.6.9 | Add loading states and skeletons | P1 | S |
-| 1.6.10 | Add error boundaries | P1 | S |
+| ID     | Story                                       | Priority | Estimate |
+| ------ | ------------------------------------------- | -------- | -------- |
+| 1.6.1  | Create app layout and navigation            | P0       | M        |
+| 1.6.2  | Build network overview page                 | P0       | L        |
+| 1.6.3  | Build node list page with sorting/filtering | P0       | L        |
+| 1.6.4  | Build node detail page                      | P0       | L        |
+| 1.6.5  | Create metric cards component               | P0       | M        |
+| 1.6.6  | Create line chart component                 | P0       | M        |
+| 1.6.7  | Add real-time update indicators             | P1       | M        |
+| 1.6.8  | Implement responsive design                 | P1       | M        |
+| 1.6.9  | Add loading states and skeletons            | P1       | S        |
+| 1.6.10 | Add error boundaries                        | P1       | S        |
 
 #### Phase 1 Success Criteria
 
@@ -375,43 +376,43 @@ Per Xandeum team (Discord, 2025-12-07):
 
 #### Epic 2.1: Network-Wide Aggregation
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 2.1.1 | Calculate total network storage capacity | P0 | M |
-| 2.1.2 | Calculate active vs. inactive nodes | P0 | M |
-| 2.1.3 | Calculate network-wide uptime percentage | P0 | M |
-| 2.1.4 | Track version distribution across network | P0 | M |
-| 2.1.5 | Calculate average node metrics | P1 | S |
+| ID    | Story                                     | Priority | Estimate |
+| ----- | ----------------------------------------- | -------- | -------- |
+| 2.1.1 | Calculate total network storage capacity  | P0       | M        |
+| 2.1.2 | Calculate active vs. inactive nodes       | P0       | M        |
+| 2.1.3 | Calculate network-wide uptime percentage  | P0       | M        |
+| 2.1.4 | Track version distribution across network | P0       | M        |
+| 2.1.5 | Calculate average node metrics            | P1       | S        |
 
 #### Epic 2.2: Historical Trends
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 2.2.1 | Implement 90-day data retention | P0 | M |
-| 2.2.2 | Create hourly/daily/weekly aggregations | P0 | L |
-| 2.2.3 | Build network growth trend visualization | P0 | M |
-| 2.2.4 | Build capacity projection charts | P1 | M |
-| 2.2.5 | Add performance comparison over time | P1 | M |
+| ID    | Story                                    | Priority | Estimate |
+| ----- | ---------------------------------------- | -------- | -------- |
+| 2.2.1 | Implement 90-day data retention          | P0       | M        |
+| 2.2.2 | Create hourly/daily/weekly aggregations  | P0       | L        |
+| 2.2.3 | Build network growth trend visualization | P0       | M        |
+| 2.2.4 | Build capacity projection charts         | P1       | M        |
+| 2.2.5 | Add performance comparison over time     | P1       | M        |
 
 #### Epic 2.3: Enhanced Dashboard
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 2.3.1 | Network health score widget | P0 | M |
-| 2.3.2 | Version distribution pie chart | P0 | S |
-| 2.3.3 | Network growth trend chart | P0 | M |
-| 2.3.4 | Top/bottom performing nodes | P1 | M |
-| 2.3.5 | Network map visualization | P2 | L |
+| ID    | Story                          | Priority | Estimate |
+| ----- | ------------------------------ | -------- | -------- |
+| 2.3.1 | Network health score widget    | P0       | M        |
+| 2.3.2 | Version distribution pie chart | P0       | S        |
+| 2.3.3 | Network growth trend chart     | P0       | M        |
+| 2.3.4 | Top/bottom performing nodes    | P1       | M        |
+| 2.3.5 | Network map visualization      | P2       | L        |
 
 #### Epic 2.4: Search & Discovery
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 2.4.1 | Search nodes by IP address | P0 | M |
-| 2.4.2 | Search nodes by public key | P0 | M |
-| 2.4.3 | Filter by version | P1 | S |
-| 2.4.4 | Filter by status (active/inactive) | P1 | S |
-| 2.4.5 | Bookmark favorite nodes | P2 | M |
+| ID    | Story                              | Priority | Estimate |
+| ----- | ---------------------------------- | -------- | -------- |
+| 2.4.1 | Search nodes by IP address         | P0       | M        |
+| 2.4.2 | Search nodes by public key         | P0       | M        |
+| 2.4.3 | Filter by version                  | P1       | S        |
+| 2.4.4 | Filter by status (active/inactive) | P1       | S        |
+| 2.4.5 | Bookmark favorite nodes            | P2       | M        |
 
 #### Phase 2 Success Criteria
 
@@ -431,51 +432,51 @@ Per Xandeum team (Discord, 2025-12-07):
 
 #### Epic 3.1: Alerting System
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 3.1.1 | Design alert rule engine | P0 | L |
-| 3.1.2 | Implement configurable thresholds | P0 | M |
-| 3.1.3 | Add email notification channel | P0 | M |
-| 3.1.4 | Add Discord webhook integration | P0 | M |
-| 3.1.5 | Add Telegram bot integration | P1 | M |
-| 3.1.6 | Build alert history and acknowledgment | P1 | M |
-| 3.1.7 | Implement alert escalation policies | P2 | L |
+| ID    | Story                                  | Priority | Estimate |
+| ----- | -------------------------------------- | -------- | -------- |
+| 3.1.1 | Design alert rule engine               | P0       | L        |
+| 3.1.2 | Implement configurable thresholds      | P0       | M        |
+| 3.1.3 | Add email notification channel         | P0       | M        |
+| 3.1.4 | Add Discord webhook integration        | P0       | M        |
+| 3.1.5 | Add Telegram bot integration           | P1       | M        |
+| 3.1.6 | Build alert history and acknowledgment | P1       | M        |
+| 3.1.7 | Implement alert escalation policies    | P2       | L        |
 
 #### Epic 3.2: Operator Dashboard
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 3.2.1 | Personal node portfolio view | P0 | L |
-| 3.2.2 | Performance benchmarking vs. network | P0 | M |
-| 3.2.3 | Uptime tracking and SLA reporting | P1 | M |
-| 3.2.4 | Resource utilization recommendations | P2 | L |
+| ID    | Story                                | Priority | Estimate |
+| ----- | ------------------------------------ | -------- | -------- |
+| 3.2.1 | Personal node portfolio view         | P0       | L        |
+| 3.2.2 | Performance benchmarking vs. network | P0       | M        |
+| 3.2.3 | Uptime tracking and SLA reporting    | P1       | M        |
+| 3.2.4 | Resource utilization recommendations | P2       | L        |
 
 #### Epic 3.3: Comparison Tools
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 3.3.1 | Side-by-side node comparison | P0 | M |
-| 3.3.2 | Identify underperforming nodes | P1 | M |
-| 3.3.3 | Version upgrade tracking | P1 | S |
-| 3.3.4 | Peer health analysis | P2 | M |
+| ID    | Story                          | Priority | Estimate |
+| ----- | ------------------------------ | -------- | -------- |
+| 3.3.1 | Side-by-side node comparison   | P0       | M        |
+| 3.3.2 | Identify underperforming nodes | P1       | M        |
+| 3.3.3 | Version upgrade tracking       | P1       | S        |
+| 3.3.4 | Peer health analysis           | P2       | M        |
 
 #### Epic 3.4: Export & Reports
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 3.4.1 | CSV data export | P0 | M |
-| 3.4.2 | JSON API export | P0 | S |
-| 3.4.3 | Scheduled email reports | P1 | M |
-| 3.4.4 | Grafana dashboard templates | P2 | L |
+| ID    | Story                       | Priority | Estimate |
+| ----- | --------------------------- | -------- | -------- |
+| 3.4.1 | CSV data export             | P0       | M        |
+| 3.4.2 | JSON API export             | P0       | S        |
+| 3.4.3 | Scheduled email reports     | P1       | M        |
+| 3.4.4 | Grafana dashboard templates | P2       | L        |
 
 #### Epic 3.5: User Accounts (Optional)
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 3.5.1 | Wallet-based authentication (Solana) | P1 | L |
-| 3.5.2 | User preferences storage | P1 | M |
-| 3.5.3 | Alert configuration persistence | P1 | M |
-| 3.5.4 | Node ownership claims | P2 | L |
+| ID    | Story                                | Priority | Estimate |
+| ----- | ------------------------------------ | -------- | -------- |
+| 3.5.1 | Wallet-based authentication (Solana) | P1       | L        |
+| 3.5.2 | User preferences storage             | P1       | M        |
+| 3.5.3 | Alert configuration persistence      | P1       | M        |
+| 3.5.4 | Node ownership claims                | P2       | L        |
 
 #### Phase 3 Success Criteria
 
@@ -495,47 +496,47 @@ Per Xandeum team (Discord, 2025-12-07):
 
 #### Epic 4.1: Public API
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 4.1.1 | Design REST API specification (OpenAPI) | P0 | M |
-| 4.1.2 | Implement versioned API endpoints | P0 | L |
-| 4.1.3 | Add API key management | P0 | M |
-| 4.1.4 | Implement usage tracking and quotas | P1 | M |
-| 4.1.5 | Create API documentation portal | P0 | L |
+| ID    | Story                                   | Priority | Estimate |
+| ----- | --------------------------------------- | -------- | -------- |
+| 4.1.1 | Design REST API specification (OpenAPI) | P0       | M        |
+| 4.1.2 | Implement versioned API endpoints       | P0       | L        |
+| 4.1.3 | Add API key management                  | P0       | M        |
+| 4.1.4 | Implement usage tracking and quotas     | P1       | M        |
+| 4.1.5 | Create API documentation portal         | P0       | L        |
 
 #### Epic 4.2: Developer SDKs
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 4.2.1 | TypeScript/JavaScript SDK | P0 | L |
-| 4.2.2 | Python SDK | P1 | L |
-| 4.2.3 | SDK documentation and examples | P0 | M |
-| 4.2.4 | Publish to npm/PyPI | P0 | S |
+| ID    | Story                          | Priority | Estimate |
+| ----- | ------------------------------ | -------- | -------- |
+| 4.2.1 | TypeScript/JavaScript SDK      | P0       | L        |
+| 4.2.2 | Python SDK                     | P1       | L        |
+| 4.2.3 | SDK documentation and examples | P0       | M        |
+| 4.2.4 | Publish to npm/PyPI            | P0       | S        |
 
 #### Epic 4.3: Integrations
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 4.3.1 | Discord notification bot | P0 | M |
-| 4.3.2 | Telegram notification bot | P1 | M |
-| 4.3.3 | Grafana data source plugin | P1 | L |
-| 4.3.4 | Prometheus metrics exporter | P2 | L |
+| ID    | Story                       | Priority | Estimate |
+| ----- | --------------------------- | -------- | -------- |
+| 4.3.1 | Discord notification bot    | P0       | M        |
+| 4.3.2 | Telegram notification bot   | P1       | M        |
+| 4.3.3 | Grafana data source plugin  | P1       | L        |
+| 4.3.4 | Prometheus metrics exporter | P2       | L        |
 
 #### Epic 4.4: Embeddable Widgets
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 4.4.1 | Network status badge (SVG) | P1 | S |
-| 4.4.2 | Node status widget (iframe) | P1 | M |
-| 4.4.3 | Embeddable charts | P2 | M |
+| ID    | Story                       | Priority | Estimate |
+| ----- | --------------------------- | -------- | -------- |
+| 4.4.1 | Network status badge (SVG)  | P1       | S        |
+| 4.4.2 | Node status widget (iframe) | P1       | M        |
+| 4.4.3 | Embeddable charts           | P2       | M        |
 
 #### Epic 4.5: Community Features
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 4.5.1 | Node leaderboards | P1 | M |
-| 4.5.2 | Operator profiles (opt-in) | P2 | M |
-| 4.5.3 | Achievement badges | P2 | M |
+| ID    | Story                      | Priority | Estimate |
+| ----- | -------------------------- | -------- | -------- |
+| 4.5.1 | Node leaderboards          | P1       | M        |
+| 4.5.2 | Operator profiles (opt-in) | P2       | M        |
+| 4.5.3 | Achievement badges         | P2       | M        |
 
 #### Phase 4 Success Criteria
 
@@ -555,35 +556,35 @@ Per Xandeum team (Discord, 2025-12-07):
 
 #### Epic 5.1: Predictive Analytics
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 5.1.1 | Capacity forecasting model | P1 | L |
-| 5.1.2 | Performance degradation prediction | P1 | L |
-| 5.1.3 | Network growth modeling | P2 | L |
+| ID    | Story                              | Priority | Estimate |
+| ----- | ---------------------------------- | -------- | -------- |
+| 5.1.1 | Capacity forecasting model         | P1       | L        |
+| 5.1.2 | Performance degradation prediction | P1       | L        |
+| 5.1.3 | Network growth modeling            | P2       | L        |
 
 #### Epic 5.2: Anomaly Detection
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 5.2.1 | Automatic outlier identification | P1 | L |
-| 5.2.2 | Pattern deviation alerts | P1 | M |
-| 5.2.3 | Network health scoring algorithm | P1 | M |
+| ID    | Story                            | Priority | Estimate |
+| ----- | -------------------------------- | -------- | -------- |
+| 5.2.1 | Automatic outlier identification | P1       | L        |
+| 5.2.2 | Pattern deviation alerts         | P1       | M        |
+| 5.2.3 | Network health scoring algorithm | P1       | M        |
 
 #### Epic 5.3: Optimization Recommendations
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 5.3.1 | Resource tuning suggestions | P2 | M |
-| 5.3.2 | Version upgrade advisories | P1 | S |
-| 5.3.3 | Peer optimization recommendations | P2 | M |
+| ID    | Story                             | Priority | Estimate |
+| ----- | --------------------------------- | -------- | -------- |
+| 5.3.1 | Resource tuning suggestions       | P2       | M        |
+| 5.3.2 | Version upgrade advisories        | P1       | S        |
+| 5.3.3 | Peer optimization recommendations | P2       | M        |
 
 #### Epic 5.4: v0.7 Heidelberg Integration
 
-| ID | Story | Priority | Estimate |
-|----|-------|----------|----------|
-| 5.4.1 | Integrate paging statistics APIs | P0 | L |
-| 5.4.2 | Extend data models for new metrics | P0 | M |
-| 5.4.3 | Update dashboard for new features | P0 | M |
+| ID    | Story                              | Priority | Estimate |
+| ----- | ---------------------------------- | -------- | -------- |
+| 5.4.1 | Integrate paging statistics APIs   | P0       | L        |
+| 5.4.2 | Extend data models for new metrics | P0       | M        |
+| 5.4.3 | Update dashboard for new features  | P0       | M        |
 
 #### Phase 5 Success Criteria
 
@@ -637,14 +638,14 @@ Per Xandeum team (Discord, 2025-12-07):
 
 ### Key Performance Indicators
 
-| Metric | Phase 1 Target | Phase 4 Target |
-|--------|----------------|----------------|
-| Weekly Active Users | 50 | 500+ |
-| API Requests/Day | 1,000 | 100,000+ |
-| Nodes Tracked | 27+ | All network nodes |
-| Uptime SLA | 99% | 99.9% |
-| Page Load Time | <3s | <1s |
-| Alert Delivery Rate | N/A | 95%+ |
+| Metric              | Phase 1 Target | Phase 4 Target    |
+| ------------------- | -------------- | ----------------- |
+| Weekly Active Users | 50             | 500+              |
+| API Requests/Day    | 1,000          | 100,000+          |
+| Nodes Tracked       | 27+            | All network nodes |
+| Uptime SLA          | 99%            | 99.9%             |
+| Page Load Time      | <3s            | <1s               |
+| Alert Delivery Rate | N/A            | 95%+              |
 
 ### Community Health
 
@@ -657,13 +658,13 @@ Per Xandeum team (Discord, 2025-12-07):
 
 ## Risk Assessment
 
-| Risk | Probability | Impact | Mitigation |
-|------|-------------|--------|------------|
-| pNodes go private (close port 6000) | Medium | Critical | Partner with Xandeum for data access |
-| Limited API surface (only 3 methods) | Known | Medium | Design for extensibility, prepare for v0.7 |
-| Xandeum network doesn't grow | Medium | High | Build generic value, pivot capability |
-| Competition enters market | Medium | Medium | First-mover advantage, community loyalty |
-| v0.7 API breaks compatibility | Low | High | Modular architecture, versioned clients |
+| Risk                                 | Probability | Impact   | Mitigation                                 |
+| ------------------------------------ | ----------- | -------- | ------------------------------------------ |
+| pNodes go private (close port 6000)  | Medium      | Critical | Partner with Xandeum for data access       |
+| Limited API surface (only 3 methods) | Known       | Medium   | Design for extensibility, prepare for v0.7 |
+| Xandeum network doesn't grow         | Medium      | High     | Build generic value, pivot capability      |
+| Competition enters market            | Medium      | Medium   | First-mover advantage, community loyalty   |
+| v0.7 API breaks compatibility        | Low         | High     | Modular architecture, versioned clients    |
 
 ---
 
@@ -683,6 +684,6 @@ Per Xandeum team (Discord, 2025-12-07):
 
 ---
 
-*This roadmap is a living document. Updated as we learn more about the ecosystem and user needs.*
+_This roadmap is a living document. Updated as we learn more about the ecosystem and user needs._
 
 **Built with Ihsan (Excellence) by RECTOR**

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -64,7 +64,7 @@ docker compose up -d
 docker compose ps
 ```
 
-Access at `http://localhost:7000`
+Access at `http://localhost:7001`
 
 ---
 
@@ -119,8 +119,8 @@ docker run --rm \
   node:20-alpine \
   sh -c "npx prisma migrate deploy"
 
-# Start web application
-docker compose up -d blue
+# Start web application (single always-on container)
+docker compose up -d green
 ```
 
 ### 5. Verify Deployment
@@ -130,7 +130,7 @@ docker compose up -d blue
 docker compose ps
 
 # Test health endpoint
-curl http://localhost:7000/api/health
+curl http://localhost:7001/api/health
 ```
 
 ---
@@ -231,7 +231,7 @@ PRPC_SEED_NODES=192.190.136.36,173.212.203.145
 
 ```bash
 # Check application logs for collection activity
-docker compose logs blue --tail 50 | grep -i collect
+docker compose logs green --tail 50 | grep -i collect
 
 # Check database for recent metrics
 docker exec pnode-pulse-postgres psql -U pnodepulse -c \
@@ -269,7 +269,7 @@ server {
     server_name pulse.yourdomain.com;
 
     location / {
-        proxy_pass http://localhost:7000;
+        proxy_pass http://localhost:7001;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -322,10 +322,10 @@ pNode Pulse includes automated deployment workflows.
 
 ### Workflows
 
-| Workflow                | Trigger        | Target                  |
-| ----------------------- | -------------- | ----------------------- |
-| `deploy-staging.yml`    | Push to `dev`  | Staging (port 7002)     |
-| `deploy-production.yml` | Push to `main` | Production (blue/green) |
+| Workflow                | Trigger        | Target                                   |
+| ----------------------- | -------------- | ---------------------------------------- |
+| `deploy-staging.yml`    | Push to `dev`  | Staging (port 7002)                      |
+| `deploy-production.yml` | Push to `main` | Production (single container, port 7001) |
 
 ### Required GitHub Secrets
 
@@ -348,48 +348,26 @@ Configure in repository Settings → Secrets:
 
 1. Push to `main` branch
 2. GitHub Actions builds Docker image
-3. Pushes to GHCR with `:latest` tag
-4. Runs blue/green deployment:
-   - Starts inactive environment (blue or green)
-   - Waits for health check
-   - Switches traffic
-   - Stops old environment
+3. Pushes to GHCR with `:latest` tag (production builds also push a `:prod-<sha>` tag for rollbacks)
+4. SSHs to VPS and runs `scripts/deploy.sh`, which:
+   - Pulls the new image (`docker compose pull green`)
+   - Recreates only the web container (`docker compose up -d --no-deps green`)
+   - Waits up to 120s for the `green` container's health check to pass (fails the deploy if it stays unhealthy)
+
+The `--no-deps` flag ensures deploys recreate **only** the web container and never touch `postgres`, `redis`, or `collector`. Because there is a single web container, the deploy is not zero-downtime: expect a brief (~5-15s) restart blip while `green` is recreated. This is acceptable for a single low-traffic instance.
 
 ### Manual Deployment
 
 ```bash
-# SSH to VPS
-ssh pnodepulse@your-vps
+# SSH to VPS (Cloudflare Tunnel alias; direct port 22 is firewalled)
+ssh pnodepulse
 
 # Pull latest changes
 cd ~/pnode-pulse
 git pull origin main
 
-# Pull latest image
-docker compose pull blue
-
-# Restart service
-docker compose up -d blue
-```
-
-### Blue/Green Switch
-
-```bash
-# Check current active environment
-docker compose ps | grep healthy
-
-# If blue is active, switch to green
-docker compose --profile green up -d green
-
-# Wait for health check
-curl http://localhost:7001/api/health
-
-# Update nginx to point to 7001
-sudo vim /etc/nginx/sites-enabled/your-site
-sudo nginx -t && sudo systemctl reload nginx
-
-# Stop old blue
-docker compose stop blue
+# Pull the new image and recreate only the web container
+SERVICE=green bash scripts/deploy.sh
 ```
 
 ---
@@ -426,7 +404,7 @@ All services have built-in health checks:
 docker compose ps
 
 # Check specific container
-docker inspect pnode-pulse-web-blue --format='{{.State.Health.Status}}'
+docker inspect pnode-pulse-web-green --format='{{.State.Health.Status}}'
 ```
 
 ### Log Monitoring
@@ -436,7 +414,7 @@ docker inspect pnode-pulse-web-blue --format='{{.State.Health.Status}}'
 docker compose logs -f
 
 # Specific service
-docker compose logs -f blue
+docker compose logs -f green
 
 # Collector only
 docker logs -f pnode-pulse-collector
@@ -450,7 +428,7 @@ docker logs -f pnode-pulse-collector
 
 ```bash
 # Check logs
-docker compose logs blue
+docker compose logs green
 
 # Verify network
 docker network ls | grep pnode-pulse
@@ -467,7 +445,7 @@ docker compose up -d
 docker exec pnode-pulse-postgres pg_isready -U pnodepulse
 
 # Check password
-docker exec pnode-pulse-web-blue printenv DATABASE_URL
+docker exec pnode-pulse-web-green printenv DATABASE_URL
 ```
 
 ### Collector Not Collecting
@@ -508,28 +486,51 @@ npx prisma migrate reset
 docker stats
 
 # Restart containers
-docker compose restart blue
+docker compose restart green
 ```
 
 ---
 
-## Blue/Green Deployment
+## Production Deployment Model
 
-For zero-downtime updates:
+Production runs a single always-on web container:
+
+| Property        | Value                                                       |
+| --------------- | ----------------------------------------------------------- |
+| Compose service | `green`                                                     |
+| Container name  | `pnode-pulse-web-green`                                     |
+| Host port       | `7001`                                                      |
+| nginx upstream  | `http://localhost:7001` (permanent — no upstream switching) |
+
+Deploys run `scripts/deploy.sh`, which pulls the new image, recreates only the web container with `--no-deps` (leaving `postgres`, `redis`, and `collector` untouched), and waits up to 120s for the container's health check before considering the deploy successful:
 
 ```bash
-# Deploy to green while blue is active
-docker compose --profile green up -d green
+# On the VPS, as pnodepulse
+cd ~/pnode-pulse
+SERVICE=green bash scripts/deploy.sh
 
-# Wait for health check
-sleep 30
+# Verify
 curl http://localhost:7001/api/health
+```
 
-# Switch nginx to green (port 7001)
-# Update nginx config and reload
+This is not zero-downtime: expect a brief (~5-15s) restart blip while `green` is recreated. Acceptable for a single low-traffic instance.
 
-# Stop blue
-docker compose stop blue
+### Rollback
+
+Production builds push a `:prod-<sha>` tag to GHCR for every commit on `main`. To roll back, re-deploy a previous image tag:
+
+```bash
+# On the VPS, as pnodepulse
+cd ~/pnode-pulse
+
+# Pull the known-good image (replace <sha> with the target commit)
+docker pull ghcr.io/rector-labs/pnode-pulse:prod-<sha>
+
+# Re-tag it as :latest so deploy.sh picks it up
+docker tag ghcr.io/rector-labs/pnode-pulse:prod-<sha> ghcr.io/rector-labs/pnode-pulse:latest
+
+# Recreate the web container with the rolled-back image
+SERVICE=green bash scripts/deploy.sh
 ```
 
 ---
@@ -541,7 +542,7 @@ docker compose stop blue
 git pull origin main
 
 # Pull latest image
-docker compose pull
+docker compose pull green
 
 # Apply migrations
 docker run --rm \
@@ -552,10 +553,10 @@ docker run --rm \
   node:20-alpine \
   sh -c "npx prisma migrate deploy"
 
-# Restart services
-docker compose up -d blue
+# Recreate only the web container (postgres/redis/collector untouched)
+SERVICE=green bash scripts/deploy.sh
 
-# Restart collector
+# Restart collector (only if its image/config changed)
 docker restart pnode-pulse-collector
 ```
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -2,7 +2,7 @@
 
 **Last Updated**: 2025-12-15  
 **Environment**: Production (pulse.rectorspace.com)  
-**VPS**: 176.222.53.185 (pnodepulse user)
+**VPS**: 151.245.137.75 (pnodepulse user)
 
 ---
 

--- a/docs/VERCEL_CUTOVER_RUNBOOK.md
+++ b/docs/VERCEL_CUTOVER_RUNBOOK.md
@@ -61,7 +61,7 @@ clashes while the new vhost is being set up.
 > **7004** — _reserved_ for pulse-api dedicated service (Tier 2 follow-on; not in use today)
 
 Today's Tier 1 cutover proxies through nginx straight to the existing
-`pnode-pulse-web-blue` container on port 7000. No new container is needed.
+`pnode-pulse-web-green` container on port 7001. No new container is needed.
 
 ---
 
@@ -136,10 +136,10 @@ server {
     proxy_buffers 8 16k;
     client_max_body_size 4m;
 
-    # Same upstream as pulse.rectorspace.com — the existing blue container.
+    # Same upstream as pulse.rectorspace.com — the existing green container.
     # When we want isolation later, this becomes a dedicated pulse-api on :7004.
     location / {
-        proxy_pass http://127.0.0.1:7000;
+        proxy_pass http://127.0.0.1:7001;
         proxy_http_version 1.1;
         proxy_set_header Host              api.pulse.rectorspace.com;
         proxy_set_header X-Real-IP         $remote_addr;
@@ -370,7 +370,7 @@ Browser test:
 
 Monitor:
 
-- `ssh reclabs3 'docker logs --tail 200 -f pnode-pulse-web-blue'` — request volume should look normal
+- `ssh reclabs3 'docker logs --tail 200 -f pnode-pulse-web-green'` — request volume should look normal
 - Vercel dashboard → Project → Analytics — request count + errors
 - Sentry (if configured) — error rate
 - nginx access log on VPS: `tail -f /var/log/nginx/api.pulse.access.log`
@@ -401,8 +401,8 @@ dig +short pulse.rectorspace.com
 # Expect: 151.245.137.75 within the TTL window (~1 min if you lowered it in Step 11)
 ```
 
-Existing VPS containers (blue/green) are still running on port 7000/7001 and
-nginx still has the original vhost — they will serve traffic again immediately.
+The single `green` container is still running on port 7001 and nginx still has
+the original vhost — it will serve traffic again immediately.
 
 ---
 
@@ -480,7 +480,7 @@ curl -fsS http://127.0.0.1:7004/readyz | jq
 # Expect: {"status":"ok","checks":{"database":true,"redis":true},...}
 # (status is "degraded" if only Redis is down — DB unreachable returns 503.)
 
-# tRPC smoke test — same procedure as `curl http://127.0.0.1:7000/api/trpc/nodes.versions`
+# tRPC smoke test — same procedure as `curl http://127.0.0.1:7001/api/trpc/nodes.versions`
 curl -fsS 'http://127.0.0.1:7004/api/trpc/nodes.versions' | jq
 ```
 
@@ -513,9 +513,9 @@ server {
         proxy_pass http://127.0.0.1:7004;
     }
 
-    # Everything else (REST, badges, metrics, realtime) → monolith :7000
+    # Everything else (REST, badges, metrics, realtime) → monolith :7001
     location / {
-        proxy_pass http://127.0.0.1:7000;
+        proxy_pass http://127.0.0.1:7001;
         proxy_http_version 1.1;
         proxy_set_header Host              api.pulse.rectorspace.com;
         proxy_set_header X-Real-IP         $remote_addr;
@@ -575,25 +575,25 @@ Only after pulse-api has been serving tRPC for 14+ days without issues:
 4. Update the FE Vercel deploy — Prisma schema is no longer needed for the
    build; remove `npx prisma generate` from `vercel.json` buildCommand and
    drop `DATABASE_URL` / `JWT_SECRET` Vercel env vars
-5. The monolith `blue`/`green` Docker containers can also be stopped once
-   nothing depends on them (all paths in the nginx vhost would already
+5. The monolith `green` Docker container can also be stopped once
+   nothing depends on it (all paths in the nginx vhost would already
    point at pulse-api or a static handler by then)
 
 ---
 
 ## What lives where after Tier 1 cutover
 
-| Component                                      | Location                                          | Talks to                  |
-| ---------------------------------------------- | ------------------------------------------------- | ------------------------- |
-| FE pages                                       | Vercel (`pulse.rectorspace.com`)                  | rewritten `/api/*` → VPS  |
-| tRPC server, REST API                          | VPS Docker `pnode-pulse-web-blue:7000` (existing) | local DB + Redis          |
-| TimescaleDB                                    | VPS Docker `pnode-pulse-postgres:5434` (existing) | —                         |
-| Redis                                          | VPS Docker `pnode-pulse-redis:6381` (existing)    | —                         |
-| Collector worker                               | VPS systemd / docker (existing)                   | local DB                  |
-| Alert processor                                | VPS (existing)                                    | local DB + Redis          |
-| Report processor                               | VPS (existing)                                    | local DB + email channels |
-| nginx vhost: `pulse.rectorspace.com`           | VPS — can be left in place as standby             | —                         |
-| nginx vhost: `api.pulse.rectorspace.com` (new) | VPS                                               | `127.0.0.1:7000`          |
+| Component                                      | Location                                               | Talks to                  |
+| ---------------------------------------------- | ------------------------------------------------------ | ------------------------- |
+| FE pages                                       | Vercel (`pulse.rectorspace.com`)                       | rewritten `/api/*` → VPS  |
+| tRPC server, REST API                          | VPS Docker `pnode-pulse-web-green:7001` (existing)     | local DB + Redis          |
+| TimescaleDB                                    | VPS Docker `pnode-pulse-postgres` (existing, internal) | —                         |
+| Redis                                          | VPS Docker `pnode-pulse-redis` (existing, internal)    | —                         |
+| Collector worker                               | VPS systemd / docker (existing)                        | local DB                  |
+| Alert processor                                | VPS (existing)                                         | local DB + Redis          |
+| Report processor                               | VPS (existing)                                         | local DB + email channels |
+| nginx vhost: `pulse.rectorspace.com`           | VPS — can be left in place as standby                  | —                         |
+| nginx vhost: `api.pulse.rectorspace.com` (new) | VPS                                                    | `127.0.0.1:7001`          |
 
 ---
 

--- a/prisma/migrations/20251209060207_add_v070_fields/README.md
+++ b/prisma/migrations/20251209060207_add_v070_fields/README.md
@@ -11,11 +11,13 @@ Adds database fields to support Xandeum v0.7.0 `get-pods-with-stats` API.
 ## Changes
 
 ### nodes table
+
 - `is_public` (BOOLEAN, nullable) - Whether RPC port is publicly accessible
 - `rpc_port` (INTEGER, nullable) - RPC service port (typically 6000)
 - Index on `is_public` for filtering
 
 ### node_metrics table
+
 - `storage_committed` (BIGINT, nullable) - Total storage allocated in bytes
 - `storage_usage_percent` (DOUBLE PRECISION, nullable) - Storage utilization percentage
 
@@ -31,9 +33,10 @@ Adds database fields to support Xandeum v0.7.0 `get-pods-with-stats` API.
 ## Application
 
 ### Staging (Test First)
+
 ```bash
 # SSH to staging VPS
-ssh pnodepulse@176.222.53.185
+ssh pnodepulse@151.245.137.75
 
 # Backup database
 pg_dump -h localhost -p 5434 -U pnodepulse pnodepulse > backup_pre_v070.sql
@@ -47,6 +50,7 @@ psql -h localhost -p 5434 -U pnodepulse pnodepulse -c "\d node_metrics"
 ```
 
 ### Production
+
 ```bash
 # Same process after staging verification
 ```
@@ -91,6 +95,7 @@ ORDER BY c.table_name, c.column_name;
 ## Post-Migration
 
 After successful migration:
+
 1. Update issue #162 status
 2. Proceed with #161 (worker updates)
 3. Monitor logs for data collection


### PR DESCRIPTION
Follow-up #1 of 4. Brings DEPLOYMENT.md, CLAUDE.md, and VERCEL_CUTOVER_RUNBOOK.md in line with the single-`green` deploy (PR #221) — port 7001, `scripts/deploy.sh`, `--no-deps`, postgres/redis internal-only — matching the already-updated `.github/workflows/README.md`.

Also corrects the stale VPS IP `176.222.53.185` → `151.245.137.75` (the VPS's actual public IP, verified via `ifconfig.me` + routing; the runbook already used the correct one) in CLAUDE.md, ROADMAP.md, docs/RUNBOOK.md, and the v070 migration README. Left the SSH-firewall doc's historical error-message IP untouched.

Docs-only; 307 tests pass.