### PR TITLE
feat(collector): productionize the data collector as a built service

### DIFF
--- a/.github/workflows/deploy-collector.yml
+++ b/.github/workflows/deploy-collector.yml
@@ -1,0 +1,115 @@
+name: Deploy collector
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "src/server/workers/**"
+      - "scripts/start-collector.ts"
+      - "src/lib/**"
+      - "prisma/schema.prisma"
+      - "Dockerfile"
+      - "package.json"
+      - ".github/workflows/deploy-collector.yml"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: rector-labs/pnode-pulse-collector
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Required so build-push-action can use cache-from/cache-to: type=gha.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=sha-
+            type=raw,value=latest
+
+      # Builds the `collector` target from the root Dockerfile (tsx + worker code).
+      # The collector stage does NOT run the Next.js build, so no DATABASE_URL arg.
+      - name: Build and push collector image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: collector
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=collector
+          cache-to: type=gha,mode=max,scope=collector
+
+      # Direct SSH to the VPS public IP is blocked by the firewall. Operators
+      # SSH via the Cloudflare Tunnel (`ssh.rectorspace.com` → VPS:22), so CI
+      # uses the same path. Tunnel is a public route; SSH key auth (VPS_SSH_KEY)
+      # remains the only authentication.
+      - name: Install cloudflared
+        run: |
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -o /tmp/cloudflared.deb
+          sudo dpkg -i /tmp/cloudflared.deb
+          cloudflared --version
+
+      - name: Load VPS SSH key into ssh-agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.VPS_SSH_KEY }}
+
+      - name: Deploy collector to VPS (via CF Tunnel)
+        run: |
+          ssh -o StrictHostKeyChecking=accept-new \
+              -o ProxyCommand="cloudflared access ssh --hostname=ssh.rectorspace.com" \
+              pnodepulse@ssh.rectorspace.com bash -s <<'REMOTE'
+          set -euo pipefail
+          cd ~/pnode-pulse
+          git fetch origin main
+          git pull --ff-only origin main
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          docker pull ghcr.io/rector-labs/pnode-pulse-collector:latest
+          # Replace any existing collector — including the legacy hand-run container
+          # (node:20 + tsx off ~/pnode-pulse-src) — and bring it up under compose.
+          # --no-deps leaves postgres/redis untouched.
+          docker rm -f pnode-pulse-collector 2>/dev/null || true
+          docker compose up -d --no-deps collector
+          # A worker has no HTTP healthcheck; confirm it stays up (not crash-looping).
+          sleep 8
+          state=$(docker inspect -f '{{.State.Status}}' pnode-pulse-collector)
+          echo "collector state: $state"
+          if [ "$state" != "running" ]; then
+            echo "ERROR: collector is not running"; docker logs --tail 50 pnode-pulse-collector; exit 1
+          fi
+          docker image prune -f
+          REMOTE
+
+      - name: Verify deployment
+        run: |
+          ssh -o StrictHostKeyChecking=accept-new \
+              -o ProxyCommand="cloudflared access ssh --hostname=ssh.rectorspace.com" \
+              pnodepulse@ssh.rectorspace.com bash -s <<'REMOTE'
+          set -euo pipefail
+          cd ~/pnode-pulse
+          docker compose ps collector
+          docker compose logs --tail 30 collector
+          REMOTE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-# Build stage
-FROM node:20-alpine AS builder
+# Dependencies + source + generated Prisma client.
+# Shared base for both the web build and the collector so they install deps once.
+FROM node:20-alpine AS deps
 
 WORKDIR /app
 
@@ -15,12 +16,22 @@ COPY . .
 # Generate Prisma client
 RUN npx prisma generate
 
-# Build Next.js
+# Web build stage
+FROM deps AS builder
+
 ARG DATABASE_URL
 ENV DATABASE_URL=${DATABASE_URL}
 RUN npm run build
 
-# Production stage
+# Collector stage — runs the data-collection worker via tsx.
+# Reuses `deps` (full deps incl. tsx, source, generated Prisma client); the
+# Next.js build is NOT needed here, so this stage skips it.
+FROM deps AS collector
+
+ENV NODE_ENV=production
+CMD ["npx", "tsx", "scripts/start-collector.ts"]
+
+# Production web stage (Next.js standalone). This is the default build target.
 FROM node:20-alpine AS runner
 
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,27 @@ services:
       timeout: 10s
       retries: 3
 
+  # Data collector worker — polls pNodes via pRPC and writes metrics/peers to the DB.
+  # Built from the `collector` Dockerfile target (tsx + the worker code). Core service:
+  # deployed via deploy-collector.yml; the web deploy (`up -d --no-deps green`) never
+  # touches it. No host ports — reaches postgres/redis on the internal network.
+  collector:
+    image: ghcr.io/rector-labs/pnode-pulse-collector:latest
+    container_name: pnode-pulse-collector
+    restart: unless-stopped
+    environment:
+      NODE_ENV: production
+      DATABASE_URL: postgresql://pnodepulse:${POSTGRES_PASSWORD}@postgres:5432/pnodepulse
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+    networks:
+      - pnode-pulse-net
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
   # pulse-api (lean Hono service hosting the tRPC server)
   # Tier 2 of the Vercel migration — see docs/VERCEL_CUTOVER_RUNBOOK.md.
   # Bound to 127.0.0.1 so nginx is the only public ingress.


### PR DESCRIPTION
Follow-up #2 of 4. Replaces the fragile hand-run collector (`node:20` + live `npm install` + `tsx` off the untracked `~/pnode-pulse-src` snapshot) with a proper built image + compose service.

- **Dockerfile**: shared `deps` stage; new `collector` target (runs `npx tsx scripts/start-collector.ts`, skips the Next build). Web `runner` build unchanged.
- **docker-compose.yml**: `collector` service (internal network, no host ports). Core service; the web deploy (`--no-deps green`) never touches it.
- **deploy-collector.yml**: builds the `collector` image + deploys via CF tunnel, replacing the legacy hand-run container (`docker rm -f` then `compose up`).

On merge: the web deploy validates the Dockerfile refactor; the collector deploy cuts over to the version-controlled image. Fallback: the `~/pnode-pulse-src` snapshot still exists if needed.