### PR TITLE
fix(collector): include start-collector.ts in the collector image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -59,5 +59,6 @@ docker-compose*
 !README.md
 docs
 
-# Scripts
-scripts/
+# Scripts — only the collector entrypoint is needed inside images
+scripts/*
+!scripts/start-collector.ts

--- a/.github/workflows/deploy-collector.yml
+++ b/.github/workflows/deploy-collector.yml
@@ -10,6 +10,7 @@ on:
       - "src/lib/**"
       - "prisma/schema.prisma"
       - "Dockerfile"
+      - ".dockerignore"
       - "package.json"
       - ".github/workflows/deploy-collector.yml"
 
@@ -93,12 +94,14 @@ jobs:
           # --no-deps leaves postgres/redis untouched.
           docker rm -f pnode-pulse-collector 2>/dev/null || true
           docker compose up -d --no-deps collector
-          # A worker has no HTTP healthcheck; confirm it stays up (not crash-looping).
-          sleep 8
+          # A worker has no HTTP healthcheck; give it time to boot, then confirm it is
+          # running AND has not crash-looped (RestartCount must stay 0).
+          sleep 15
           state=$(docker inspect -f '{{.State.Status}}' pnode-pulse-collector)
-          echo "collector state: $state"
-          if [ "$state" != "running" ]; then
-            echo "ERROR: collector is not running"; docker logs --tail 50 pnode-pulse-collector; exit 1
+          restarts=$(docker inspect -f '{{.RestartCount}}' pnode-pulse-collector)
+          echo "collector state=$state restarts=$restarts"
+          if [ "$state" != "running" ] || [ "$restarts" -gt 0 ]; then
+            echo "ERROR: collector unhealthy (state=$state restarts=$restarts)"; docker logs --tail 50 pnode-pulse-collector; exit 1
           fi
           docker image prune -f
           REMOTE


### PR DESCRIPTION
The collector image crash-looped (`ERR_MODULE_NOT_FOUND: /app/scripts/start-collector.ts`) — `.dockerignore` excluded `scripts/`. Re-include just the entrypoint (`scripts/*` + `!scripts/start-collector.ts`) and harden the deploy check (wait 15s, fail on `RestartCount > 0`; the prior 8s check passed before tsx crashed). Follows #224.