### PR TITLE
feat(vercel): proxy /api/* to VPS backend for Tier 1 front-end

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/next.config.ts
+++ b/next.config.ts
@@ -60,6 +60,23 @@ const nextConfig: NextConfig = {
     ];
   },
 
+  // Tier-1 Vercel migration: when running as the Vercel front-end (PULSE_API_URL
+  // set), proxy every /api/* request to the VPS backend so the browser stays
+  // same-origin (no CORS, no client changes). beforeFiles => precedence over the
+  // locally-built API route handlers (an afterFiles/vercel.json rewrite is
+  // shadowed by static routes like /api/health). Gated on PULSE_API_URL so the
+  // VPS monolith and local dev (var unset) serve /api/* themselves and never
+  // proxy to themselves (which would infinite-loop).
+  async rewrites() {
+    const apiUrl = process.env.PULSE_API_URL;
+    if (!apiUrl) return [];
+    return {
+      beforeFiles: [
+        { source: "/api/:path*", destination: `${apiUrl}/api/:path*` },
+      ],
+    };
+  },
+
   // Optimize images
   images: {
     formats: ["image/avif", "image/webp"],

--- a/vercel.json
+++ b/vercel.json
@@ -3,12 +3,6 @@
   "buildCommand": "npx prisma generate && next build",
   "framework": "nextjs",
   "regions": ["fra1"],
-  "rewrites": [
-    {
-      "source": "/api/:path*",
-      "destination": "https://api.pulse.rectorspace.com/api/:path*"
-    }
-  ],
   "github": {
     "silent": true
   }


### PR DESCRIPTION
## Tier 1 Vercel cutover (#4) — front-end proxy

Enables the Vercel-hosted front-end to serve pnode-pulse while the API, database, Redis, and workers stay on the VPS. The browser stays same-origin (`/api/*` on the Vercel domain) — no CORS changes, no client edits.

### Changes
- **next.config.ts** — `beforeFiles` rewrite `/api/:path* → $PULSE_API_URL/api/:path*`, gated on `PULSE_API_URL` (set only on Vercel).
  - `beforeFiles` is required: an `afterFiles`/`vercel.json` rewrite is shadowed by **static** API routes (`/api/health`, `/api/v1/nodes`, …), which then fall through to broken local Vercel functions. `beforeFiles` precedes all local routes.
  - The `PULSE_API_URL` gate keeps the VPS monolith and local dev (var unset) serving `/api/*` themselves — no self-proxy loop.
- **vercel.json** — drop the superseded `afterFiles` `/api` rewrite.
- **.npmrc** — `legacy-peer-deps=true` so every install (Vercel, Docker, CI, local) resolves `react-simple-maps` against React 19 consistently.

### Verified on a Vercel preview
- `/api/health` → 200, `db:true` (VPS, uptime 67k) — was 503/`db:false` (cold local fn) pre-fix
- `/api/v1/nodes`, `/api/badge/nodes`, `/api/trpc/*` → 200 with live VPS data
- `Access-Control-Allow-Origin` not duplicated on `/api/v1/*`
- typecheck clean, 307/307 tests pass

### Deploy impact on merge
- Vercel Git integration deploys the FE to `pnode-pulse.vercel.app` (no custom domain yet — that's the gated Phase C).
- VPS `deploy-production.yml` rebuilds the `green` container (~5–15s blip). The `next.config` change is a **no-op at runtime on the VPS** (`PULSE_API_URL` unset there), so behavior is unchanged.

Does **not** touch `pulse.rectorspace.com` DNS — Phase C remains gated.
