### PR TITLE
fix(api): repair broken REST latest-metric endpoints (LATERAL + real table names)

### DIFF
--- a/src/app/api/badge/[type]/route.ts
+++ b/src/app/api/badge/[type]/route.ts
@@ -98,7 +98,7 @@ function formatUptime(seconds: number): string {
  */
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ type: string }> }
+  { params }: { params: Promise<{ type: string }> },
 ) {
   try {
     const { type: typeWithExt } = await params;
@@ -167,11 +167,17 @@ export async function GET(
 
       case "storage": {
         const result = await db.$queryRaw<Array<{ total: bigint }>>`
-          SELECT COALESCE(SUM("fileSize"), 0) as total
+          SELECT COALESCE(SUM(file_size), 0) as total
           FROM (
-            SELECT DISTINCT ON ("nodeId") "fileSize"
-            FROM "NodeMetric"
-            ORDER BY "nodeId", time DESC
+            SELECT m.file_size
+            FROM nodes n
+            JOIN LATERAL (
+              SELECT nm.file_size
+              FROM node_metrics nm
+              WHERE nm.node_id = n.id
+              ORDER BY nm.time DESC
+              LIMIT 1
+            ) m ON true
           ) latest
         `;
         const total = Number(result[0]?.total ?? 0);
@@ -188,9 +194,15 @@ export async function GET(
         const result = await db.$queryRaw<Array<{ avg_uptime: number }>>`
           SELECT COALESCE(AVG(uptime), 0) as avg_uptime
           FROM (
-            SELECT DISTINCT ON ("nodeId") uptime
-            FROM "NodeMetric"
-            ORDER BY "nodeId", time DESC
+            SELECT m.uptime
+            FROM nodes n
+            JOIN LATERAL (
+              SELECT nm.uptime
+              FROM node_metrics nm
+              WHERE nm.node_id = n.id
+              ORDER BY nm.time DESC
+              LIMIT 1
+            ) m ON true
           ) latest
         `;
         const avgUptime = result[0]?.avg_uptime ?? 0;
@@ -213,12 +225,15 @@ export async function GET(
       },
     });
   } catch (error) {
-    logger.error("Badge Error:", error instanceof Error ? error : new Error(String(error)));
+    logger.error(
+      "Badge Error:",
+      error instanceof Error ? error : new Error(String(error)),
+    );
 
     // Return error badge
     const errorBadge = generateBadge(
       { label: "pNode", value: "error", color: "#e05d44" },
-      "flat"
+      "flat",
     );
 
     return new NextResponse(errorBadge, {

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -24,18 +24,56 @@ export const dynamic = "force-dynamic";
 
 export async function GET() {
   try {
-    // Get all nodes with latest metrics
+    // Get all nodes with peer counts (latest metric is fetched separately below)
     const nodes = await db.node.findMany({
       include: {
-        metrics: {
-          orderBy: { time: "desc" },
-          take: 1,
-        },
         _count: {
           select: { peers: true },
         },
       },
     });
+
+    // Latest metric per node via a single LATERAL query (one indexed lookup per node).
+    // Replaces Prisma's `include: { metrics: { take: 1 } }`, which generates a
+    // ROW_NUMBER() window over the entire node_metrics hypertable (~90s, pool-exhausting).
+    const latestMetricRows = await db.$queryRaw<
+      Array<{
+        node_id: number;
+        cpu_percent: number | null;
+        ram_used: bigint | null;
+        ram_total: bigint | null;
+        file_size: bigint | null;
+        uptime: number | null;
+        packets_received: number | null;
+        packets_sent: number | null;
+      }>
+    >`
+      SELECT m.node_id, m.cpu_percent, m.ram_used, m.ram_total, m.file_size, m.uptime, m.packets_received, m.packets_sent
+      FROM nodes n
+      JOIN LATERAL (
+        SELECT nm.node_id, nm.cpu_percent, nm.ram_used, nm.ram_total, nm.file_size, nm.uptime, nm.packets_received, nm.packets_sent
+        FROM node_metrics nm
+        WHERE nm.node_id = n.id
+        ORDER BY nm.time DESC
+        LIMIT 1
+      ) m ON true
+    `;
+
+    // Map by node id, shaped to match the previous `node.metrics[0]` (camelCase) fields.
+    const latestByNode = new Map(
+      latestMetricRows.map((r) => [
+        r.node_id,
+        {
+          cpuPercent: r.cpu_percent,
+          ramUsed: r.ram_used,
+          ramTotal: r.ram_total,
+          fileSize: r.file_size,
+          uptime: r.uptime,
+          packetsReceived: r.packets_received,
+          packetsSent: r.packets_sent,
+        },
+      ]),
+    );
 
     // Get network stats
     const activeNodes = nodes.filter((n) => n.isActive).length;
@@ -52,25 +90,35 @@ export async function GET() {
         total_packets_sent: bigint;
       }>
     >`
-      SELECT
-        COALESCE(SUM(m."fileSize"), 0) as total_storage,
-        COALESCE(AVG(m."cpuPercent"), 0) as avg_cpu,
-        COALESCE(AVG(
-          CASE WHEN m."ramTotal" > 0
-            THEN (m."ramUsed"::float / m."ramTotal"::float) * 100
+      WITH latest_metrics AS (
+        SELECT
+          m.file_size,
+          m.cpu_percent,
+          CASE WHEN m.ram_total > 0
+            THEN (m.ram_used::float / m.ram_total::float) * 100
             ELSE 0
-          END
-        ), 0) as avg_ram,
-        COALESCE(AVG(m.uptime), 0) as avg_uptime,
-        COALESCE(SUM(m."packetsReceived"), 0) as total_packets_received,
-        COALESCE(SUM(m."packetsSent"), 0) as total_packets_sent
-      FROM (
-        SELECT DISTINCT ON ("nodeId") *
-        FROM "NodeMetric"
-        ORDER BY "nodeId", time DESC
-      ) m
-      JOIN "Node" n ON m."nodeId" = n.id
-      WHERE n."isActive" = true
+          END as ram_percent,
+          m.uptime,
+          m.packets_received,
+          m.packets_sent
+        FROM nodes n
+        JOIN LATERAL (
+          SELECT nm.file_size, nm.cpu_percent, nm.ram_used, nm.ram_total, nm.uptime, nm.packets_received, nm.packets_sent
+          FROM node_metrics nm
+          WHERE nm.node_id = n.id
+          ORDER BY nm.time DESC
+          LIMIT 1
+        ) m ON true
+        WHERE n.is_active = true
+      )
+      SELECT
+        COALESCE(SUM(file_size), 0) as total_storage,
+        COALESCE(AVG(cpu_percent), 0) as avg_cpu,
+        COALESCE(AVG(ram_percent), 0) as avg_ram,
+        COALESCE(AVG(uptime), 0) as avg_uptime,
+        COALESCE(SUM(packets_received), 0) as total_packets_received,
+        COALESCE(SUM(packets_sent), 0) as total_packets_sent
+      FROM latest_metrics
     `;
 
     const agg = aggregateMetrics[0] || {
@@ -83,20 +131,27 @@ export async function GET() {
     };
 
     // Get version distribution
-    const versionCounts = nodes.reduce((acc, node) => {
-      const version = node.version || "unknown";
-      acc[version] = (acc[version] || 0) + 1;
-      return acc;
-    }, {} as Record<string, number>);
+    const versionCounts = nodes.reduce(
+      (acc, node) => {
+        const version = node.version || "unknown";
+        acc[version] = (acc[version] || 0) + 1;
+        return acc;
+      },
+      {} as Record<string, number>,
+    );
 
     // Build Prometheus metrics
     const lines: string[] = [];
     const timestamp = Date.now();
 
     // Scrape info
-    lines.push("# HELP pnode_scrape_timestamp_seconds Unix timestamp of the last scrape");
+    lines.push(
+      "# HELP pnode_scrape_timestamp_seconds Unix timestamp of the last scrape",
+    );
     lines.push("# TYPE pnode_scrape_timestamp_seconds gauge");
-    lines.push(`pnode_scrape_timestamp_seconds ${Math.floor(timestamp / 1000)}`);
+    lines.push(
+      `pnode_scrape_timestamp_seconds ${Math.floor(timestamp / 1000)}`,
+    );
     lines.push("");
 
     // Network-level metrics
@@ -116,32 +171,46 @@ export async function GET() {
     lines.push("");
 
     // Network aggregate metrics
-    lines.push("# HELP pnode_network_storage_bytes Total storage across all active nodes");
+    lines.push(
+      "# HELP pnode_network_storage_bytes Total storage across all active nodes",
+    );
     lines.push("# TYPE pnode_network_storage_bytes gauge");
     lines.push(`pnode_network_storage_bytes ${agg.total_storage}`);
     lines.push("");
 
-    lines.push("# HELP pnode_network_cpu_percent Average CPU usage across all active nodes");
+    lines.push(
+      "# HELP pnode_network_cpu_percent Average CPU usage across all active nodes",
+    );
     lines.push("# TYPE pnode_network_cpu_percent gauge");
-    lines.push(`pnode_network_cpu_percent ${(agg.avg_cpu).toFixed(2)}`);
+    lines.push(`pnode_network_cpu_percent ${agg.avg_cpu.toFixed(2)}`);
     lines.push("");
 
-    lines.push("# HELP pnode_network_ram_percent Average RAM usage across all active nodes");
+    lines.push(
+      "# HELP pnode_network_ram_percent Average RAM usage across all active nodes",
+    );
     lines.push("# TYPE pnode_network_ram_percent gauge");
-    lines.push(`pnode_network_ram_percent ${(agg.avg_ram).toFixed(2)}`);
+    lines.push(`pnode_network_ram_percent ${agg.avg_ram.toFixed(2)}`);
     lines.push("");
 
-    lines.push("# HELP pnode_network_uptime_seconds Average uptime across all active nodes");
+    lines.push(
+      "# HELP pnode_network_uptime_seconds Average uptime across all active nodes",
+    );
     lines.push("# TYPE pnode_network_uptime_seconds gauge");
     lines.push(`pnode_network_uptime_seconds ${Math.round(agg.avg_uptime)}`);
     lines.push("");
 
-    lines.push("# HELP pnode_network_packets_received_total Total packets received across all active nodes");
+    lines.push(
+      "# HELP pnode_network_packets_received_total Total packets received across all active nodes",
+    );
     lines.push("# TYPE pnode_network_packets_received_total counter");
-    lines.push(`pnode_network_packets_received_total ${agg.total_packets_received}`);
+    lines.push(
+      `pnode_network_packets_received_total ${agg.total_packets_received}`,
+    );
     lines.push("");
 
-    lines.push("# HELP pnode_network_packets_sent_total Total packets sent across all active nodes");
+    lines.push(
+      "# HELP pnode_network_packets_sent_total Total packets sent across all active nodes",
+    );
     lines.push("# TYPE pnode_network_packets_sent_total counter");
     lines.push(`pnode_network_packets_sent_total ${agg.total_packets_sent}`);
     lines.push("");
@@ -166,7 +235,7 @@ export async function GET() {
     lines.push("# HELP pnode_cpu_percent CPU usage percentage");
     lines.push("# TYPE pnode_cpu_percent gauge");
     for (const node of nodes) {
-      const m = node.metrics[0];
+      const m = latestByNode.get(node.id);
       if (m?.cpuPercent !== null && m?.cpuPercent !== undefined) {
         const labels = `node="${node.address.split(":")[0]}"`;
         lines.push(`pnode_cpu_percent{${labels}} ${m.cpuPercent}`);
@@ -177,7 +246,7 @@ export async function GET() {
     lines.push("# HELP pnode_ram_used_bytes RAM used in bytes");
     lines.push("# TYPE pnode_ram_used_bytes gauge");
     for (const node of nodes) {
-      const m = node.metrics[0];
+      const m = latestByNode.get(node.id);
       if (m?.ramUsed) {
         const labels = `node="${node.address.split(":")[0]}"`;
         lines.push(`pnode_ram_used_bytes{${labels}} ${m.ramUsed}`);
@@ -188,7 +257,7 @@ export async function GET() {
     lines.push("# HELP pnode_ram_total_bytes Total RAM in bytes");
     lines.push("# TYPE pnode_ram_total_bytes gauge");
     for (const node of nodes) {
-      const m = node.metrics[0];
+      const m = latestByNode.get(node.id);
       if (m?.ramTotal) {
         const labels = `node="${node.address.split(":")[0]}"`;
         lines.push(`pnode_ram_total_bytes{${labels}} ${m.ramTotal}`);
@@ -199,7 +268,7 @@ export async function GET() {
     lines.push("# HELP pnode_ram_percent RAM usage percentage");
     lines.push("# TYPE pnode_ram_percent gauge");
     for (const node of nodes) {
-      const m = node.metrics[0];
+      const m = latestByNode.get(node.id);
       if (m?.ramUsed && m?.ramTotal && m.ramTotal > BigInt(0)) {
         const labels = `node="${node.address.split(":")[0]}"`;
         const percent = (Number(m.ramUsed) / Number(m.ramTotal)) * 100;
@@ -211,7 +280,7 @@ export async function GET() {
     lines.push("# HELP pnode_storage_bytes Storage size in bytes");
     lines.push("# TYPE pnode_storage_bytes gauge");
     for (const node of nodes) {
-      const m = node.metrics[0];
+      const m = latestByNode.get(node.id);
       if (m?.fileSize) {
         const labels = `node="${node.address.split(":")[0]}"`;
         lines.push(`pnode_storage_bytes{${labels}} ${m.fileSize}`);
@@ -222,7 +291,7 @@ export async function GET() {
     lines.push("# HELP pnode_uptime_seconds Node uptime in seconds");
     lines.push("# TYPE pnode_uptime_seconds counter");
     for (const node of nodes) {
-      const m = node.metrics[0];
+      const m = latestByNode.get(node.id);
       if (m?.uptime !== null && m?.uptime !== undefined) {
         const labels = `node="${node.address.split(":")[0]}"`;
         lines.push(`pnode_uptime_seconds{${labels}} ${m.uptime}`);
@@ -233,10 +302,12 @@ export async function GET() {
     lines.push("# HELP pnode_packets_received_total Total packets received");
     lines.push("# TYPE pnode_packets_received_total counter");
     for (const node of nodes) {
-      const m = node.metrics[0];
+      const m = latestByNode.get(node.id);
       if (m?.packetsReceived !== null && m?.packetsReceived !== undefined) {
         const labels = `node="${node.address.split(":")[0]}"`;
-        lines.push(`pnode_packets_received_total{${labels}} ${m.packetsReceived}`);
+        lines.push(
+          `pnode_packets_received_total{${labels}} ${m.packetsReceived}`,
+        );
       }
     }
     lines.push("");
@@ -244,7 +315,7 @@ export async function GET() {
     lines.push("# HELP pnode_packets_sent_total Total packets sent");
     lines.push("# TYPE pnode_packets_sent_total counter");
     for (const node of nodes) {
-      const m = node.metrics[0];
+      const m = latestByNode.get(node.id);
       if (m?.packetsSent !== null && m?.packetsSent !== undefined) {
         const labels = `node="${node.address.split(":")[0]}"`;
         lines.push(`pnode_packets_sent_total{${labels}} ${m.packetsSent}`);
@@ -275,7 +346,10 @@ export async function GET() {
       },
     });
   } catch (error) {
-    logger.error("Metrics error:", error instanceof Error ? error : new Error(String(error)));
+    logger.error(
+      "Metrics error:",
+      error instanceof Error ? error : new Error(String(error)),
+    );
     return new NextResponse("# Error generating metrics", {
       status: 500,
       headers: { "Content-Type": "text/plain" },

--- a/src/app/api/v1/network/route.ts
+++ b/src/app/api/v1/network/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { logger } from "@/lib/logger";
-import {  checkRateLimit,
+import {
+  checkRateLimit,
   createRateLimitHeaders,
   rateLimitExceededResponse,
   trackApiUsage,
@@ -46,24 +47,32 @@ export async function GET(request: NextRequest) {
         node_count: number;
       }>
     >`
-      SELECT
-        COALESCE(SUM(m."fileSize"), 0) as total_storage,
-        COALESCE(AVG(m."cpuPercent"), 0) as avg_cpu,
-        COALESCE(AVG(
-          CASE WHEN m."ramTotal" > 0
-            THEN (m."ramUsed"::float / m."ramTotal"::float) * 100
+      WITH latest_metrics AS (
+        SELECT
+          m.file_size,
+          m.cpu_percent,
+          CASE WHEN m.ram_total > 0
+            THEN (m.ram_used::float / m.ram_total::float) * 100
             ELSE 0
-          END
-        ), 0) as avg_ram_percent,
-        COALESCE(AVG(m.uptime), 0) as avg_uptime,
-        COUNT(DISTINCT m."nodeId") as node_count
-      FROM (
-        SELECT DISTINCT ON ("nodeId") *
-        FROM "NodeMetric"
-        ORDER BY "nodeId", time DESC
-      ) m
-      JOIN "Node" n ON m."nodeId" = n.id
-      WHERE n."isActive" = true
+          END as ram_percent,
+          m.uptime
+        FROM nodes n
+        JOIN LATERAL (
+          SELECT nm.file_size, nm.cpu_percent, nm.ram_used, nm.ram_total, nm.uptime
+          FROM node_metrics nm
+          WHERE nm.node_id = n.id
+          ORDER BY nm.time DESC
+          LIMIT 1
+        ) m ON true
+        WHERE n.is_active = true
+      )
+      SELECT
+        COALESCE(SUM(file_size), 0) as total_storage,
+        COALESCE(AVG(cpu_percent), 0) as avg_cpu,
+        COALESCE(AVG(ram_percent), 0) as avg_ram_percent,
+        COALESCE(AVG(uptime), 0) as avg_uptime,
+        COUNT(*) as node_count
+      FROM latest_metrics
     `;
 
     const metrics = latestMetrics[0] || {
@@ -102,7 +111,7 @@ export async function GET(request: NextRequest) {
       "/api/v1/network",
       "GET",
       responseTime,
-      false
+      false,
     );
 
     return NextResponse.json(response, {
@@ -112,7 +121,10 @@ export async function GET(request: NextRequest) {
       },
     });
   } catch (error) {
-    logger.error("API Error:", error instanceof Error ? error : new Error(String(error)));
+    logger.error(
+      "API Error:",
+      error instanceof Error ? error : new Error(String(error)),
+    );
 
     const responseTime = Date.now() - startTime;
     trackApiUsage(
@@ -120,12 +132,17 @@ export async function GET(request: NextRequest) {
       "/api/v1/network",
       "GET",
       responseTime,
-      true
+      true,
     );
 
     return NextResponse.json(
-      { error: { code: "INTERNAL_ERROR", message: "An unexpected error occurred" } },
-      { status: 500 }
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "An unexpected error occurred",
+        },
+      },
+      { status: 500 },
     );
   }
 }

--- a/src/app/api/v1/network/stats/route.ts
+++ b/src/app/api/v1/network/stats/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { logger } from "@/lib/logger";
-import {  checkRateLimit,
+import {
+  checkRateLimit,
   createRateLimitHeaders,
   rateLimitExceededResponse,
   trackApiUsage,
@@ -44,45 +45,56 @@ export async function GET(request: NextRequest) {
       }>
     >`
       WITH latest_metrics AS (
-        SELECT DISTINCT ON ("nodeId")
-          "nodeId",
-          "cpuPercent",
-          CASE WHEN "ramTotal" > 0
-            THEN ("ramUsed"::float / "ramTotal"::float) * 100
+        SELECT
+          m.cpu_percent,
+          CASE WHEN m.ram_total > 0
+            THEN (m.ram_used::float / m.ram_total::float) * 100
             ELSE 0
           END as ram_percent,
-          "fileSize",
-          uptime
-        FROM "NodeMetric"
-        ORDER BY "nodeId", time DESC
+          m.file_size,
+          m.uptime
+        FROM nodes n
+        JOIN LATERAL (
+          SELECT nm.cpu_percent, nm.ram_used, nm.ram_total, nm.file_size, nm.uptime
+          FROM node_metrics nm
+          WHERE nm.node_id = n.id
+          ORDER BY nm.time DESC
+          LIMIT 1
+        ) m ON true
+        WHERE n.is_active = true
       )
       SELECT
-        AVG("cpuPercent") as avg_cpu,
-        MIN("cpuPercent") as min_cpu,
-        MAX("cpuPercent") as max_cpu,
-        PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY "cpuPercent") as p50_cpu,
-        PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY "cpuPercent") as p90_cpu,
-        PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY "cpuPercent") as p99_cpu,
+        AVG(cpu_percent) as avg_cpu,
+        MIN(cpu_percent) as min_cpu,
+        MAX(cpu_percent) as max_cpu,
+        PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY cpu_percent) as p50_cpu,
+        PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY cpu_percent) as p90_cpu,
+        PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY cpu_percent) as p99_cpu,
         AVG(ram_percent) as avg_ram_percent,
         MIN(ram_percent) as min_ram_percent,
         MAX(ram_percent) as max_ram_percent,
         PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ram_percent) as p50_ram,
         PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY ram_percent) as p90_ram,
         PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY ram_percent) as p99_ram,
-        SUM("fileSize") as total_storage,
-        AVG("fileSize") as avg_storage,
+        SUM(file_size) as total_storage,
+        AVG(file_size) as avg_storage,
         AVG(uptime) as avg_uptime,
         COUNT(*) as node_count
-      FROM latest_metrics m
-      JOIN "Node" n ON m."nodeId" = n.id
-      WHERE n."isActive" = true
+      FROM latest_metrics
     `;
 
     const s = stats[0];
     if (!s) {
       return NextResponse.json({
         cpu: { avg: 0, min: 0, max: 0, p50: 0, p90: 0, p99: 0 },
-        ram: { avgPercent: 0, minPercent: 0, maxPercent: 0, p50: 0, p90: 0, p99: 0 },
+        ram: {
+          avgPercent: 0,
+          minPercent: 0,
+          maxPercent: 0,
+          p50: 0,
+          p90: 0,
+          p99: 0,
+        },
         storage: { total: 0, avg: 0 },
         uptime: { avgSeconds: 0 },
         nodeCount: 0,
@@ -119,7 +131,13 @@ export async function GET(request: NextRequest) {
     const rateLimitHeaders = createRateLimitHeaders(rateLimitResult);
     const responseTime = Date.now() - startTime;
 
-    trackApiUsage(rateLimitResult.apiKeyId, "/api/v1/network/stats", "GET", responseTime, false);
+    trackApiUsage(
+      rateLimitResult.apiKeyId,
+      "/api/v1/network/stats",
+      "GET",
+      responseTime,
+      false,
+    );
 
     return NextResponse.json(response, {
       headers: {
@@ -128,14 +146,28 @@ export async function GET(request: NextRequest) {
       },
     });
   } catch (error) {
-    logger.error("API Error:", error instanceof Error ? error : new Error(String(error)));
+    logger.error(
+      "API Error:",
+      error instanceof Error ? error : new Error(String(error)),
+    );
 
     const responseTime = Date.now() - startTime;
-    trackApiUsage(rateLimitResult.apiKeyId, "/api/v1/network/stats", "GET", responseTime, true);
+    trackApiUsage(
+      rateLimitResult.apiKeyId,
+      "/api/v1/network/stats",
+      "GET",
+      responseTime,
+      true,
+    );
 
     return NextResponse.json(
-      { error: { code: "INTERNAL_ERROR", message: "An unexpected error occurred" } },
-      { status: 500 }
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "An unexpected error occurred",
+        },
+      },
+      { status: 500 },
     );
   }
 }


### PR DESCRIPTION
## Problem

Several public REST endpoints were failing in production:

| Endpoint | Before |
|---|---|
| `GET /api/v1/network` | **500** (handoff had mislabeled this "slow") |
| `GET /api/v1/network/stats` | **500** |
| `GET /api/metrics` | **502 after ~120s** (connection-pool-exhaustion vector) |
| `GET /api/badge/storage.svg`, `/api/badge/uptime.svg` | broken (error badge) |

## Root cause

These routes built their "latest metric per node" aggregation with **raw SQL that referenced Prisma *model* names** (`"NodeMetric"`, `"Node"`, `"nodeId"`, `"cpuPercent"`, …) instead of the `@@map`'d **table/column** names (`node_metrics`, `nodes`, `node_id`, `cpu_percent`, …). Those relations don't exist, so the queries threw `relation "NodeMetric" does not exist`.

`/api/metrics` had a second issue: it loaded the latest metric per node via Prisma `include: { metrics: { take: 1 } }`, which generates a `ROW_NUMBER()` window over the **entire `node_metrics` hypertable** — the same ~90s pool-exhausting pattern #227 removed from the tRPC routers.

The unit suite mocks Prisma, so these raw-SQL errors never surfaced; the Playwright e2e test that asserts `/api/v1/network` → 200 is excluded from `vitest run` and isn't gating CI.

## Fix

Rewrite each to the **`LATERAL`-join shape validated in #227**: drive from `nodes` and do one indexed `(node_id, time DESC)` `LIMIT 1` lookup per node. For `/api/metrics`, replace the slow Prisma include with a single `LATERAL` query mapped by node id (shaped to the existing `node.metrics[0]` camelCase fields, so the Prometheus output is unchanged).

`/api/v1/leaderboard` was **already correct** (a `GROUP BY` over snake_case tables, no `DISTINCT ON`) and is left untouched.

## Validation

- `npm run typecheck` clean · `npx vitest run` 307/307 · `eslint` clean · `next build` OK.
- **Prod `EXPLAIN`** (real DB): cost ~**4.09M → ~1.3k**; plans use `nodes_is_active_idx` + per-chunk `node_id_time_idx` `LIMIT 1` lookups.
- **Prod equivalence**: latest-row-per-node sets are **byte-identical** between the corrected `DISTINCT ON` and the new `LATERAL` forms (`EXCEPT` both directions = 0, for both active-node and all-node semantics) — so every downstream aggregate (sum/avg/min/max/percentile/count) is identical.

## Deploy note

Merging triggers `deploy-production.yml` (VPS `green` rebuild, ~5–15s blip) + a Vercel git deploy. Post-deploy verification: the four endpoints return 200/SVG and fast, and `pg_stat_activity` stays clean.
