### PR TITLE
ci: run CI on main, not the retired master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [master, dev]
+    branches: [main, dev]
   push:
-    branches: [master, dev]
+    branches: [dev]
 
 jobs:
   lint:


### PR DESCRIPTION
## Problem
`ci.yml` triggered on `[master, dev]`, but the repo moved to `main` long ago — so lint/typecheck/build has not gated a single main-targeted PR since **2026-02-02** (~3 months).

## Fix
- `pull_request: [main, dev]` — restores the gate on PRs to main.
- `push: [dev]` (was `[master, dev]`) — `ci.yml`'s `docker` job pushes an image on `push`; main's image build is owned solely by `deploy-production.yml`, so triggering ci on main push would double-build. Dev keeps its image build.

## Verified
`npm run typecheck` + `npm run lint` both green locally before restoring, so the gate returns green rather than red on accumulated debt.

Note: this PR won't show the new checks — `pull_request` triggers are read from the base branch's workflow, which still has the old config until this merges. The next PR to main exercises the restored gate.