### PR TITLE
chore: migrate app runtime from Node 20 (EOL) to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
 
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Dependencies + source + generated Prisma client.
 # Shared base for both the web build and the collector so they install deps once.
-FROM node:20-alpine AS deps
+FROM node:24-alpine AS deps
 
 WORKDIR /app
 
@@ -32,7 +32,7 @@ ENV NODE_ENV=production
 CMD ["npx", "tsx", "scripts/start-collector.ts"]
 
 # Production web stage (Next.js standalone). This is the default build target.
-FROM node:20-alpine AS runner
+FROM node:24-alpine AS runner
 
 WORKDIR /app
 


### PR DESCRIPTION
## What
Migrates the application runtime from **Node 20 (EOL)** to **Node 24 LTS** — web image, collector, and CI.

- `Dockerfile`: `node:20-alpine` → `node:24-alpine` (`deps` + `runner`; `builder` and `collector` inherit `deps`).
- `ci.yml`: `node-version` `20` → `24` (lint + build jobs).

## Why
Node 20 is past EOL (no security patches); Node 24 is the current LTS.

## Why it's low-risk
- Stack is already 24-ready: **Next 16** (needs Node ≥20.9, supports 24), **React 19**, **Prisma 6**, **undici 7**; **no native-gyp deps**, **no `engines.node` cap**.
- `packages/pulse-api` already runs `node:24-alpine` — the tree is proven on 24.
- `Dockerfile` installs with `npm ci --ignore-scripts`, so there's no native compile step in the image.
- ci/prod parity preserved — both move to 24 together.

## Validation
- The CI gate restored in #232 builds + lints this **under Node 24** on this PR.
- On merge, `deploy-production` (node:24 web image) + `deploy-collector` (node:24 collector) run the post-deploy smoke test + health gate; `prod-<sha>` rollback ready.