### PR TITLE
ci(deploy): skip prod redeploy on docs-only changes

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:  # Manual trigger available
   push:
     branches: [main]  # Auto-deploy on main push
+    paths-ignore:     # docs-only changes shouldn't rebuild/redeploy prod
+      - '**.md'
+      - 'docs/**'
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## What
Adds `paths-ignore: ['**.md', 'docs/**']` to `deploy-production.yml`'s `push` trigger.

## Why
`deploy-production` triggers on *any* push to `main` (no path filter), so docs-only merges rebuild the image and recreate `green` — an unnecessary ~10s prod blip. This skips redeploy when a commit touches only markdown / `docs/`. Mixed commits (code + docs) still deploy, since not all changed files are ignored.

## Note
This PR itself still deploys (it changes a workflow file, not a `.md`). After it merges, the follow-up `CLAUDE.md` docs refresh won't blip prod — which doubles as the proof that this works.