### PR TITLE
docs: finish staging removal + retire blue/green in living docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -688,9 +688,8 @@ console.log(pods);
 
 **Deployment Infrastructure** ✅ COMPLETE
 
-- [x] GitHub Actions workflow for staging (dev branch)
 - [x] GitHub Actions workflow for production (main branch, single-container deploy)
-- [x] Docker Compose configuration with multi-environment support
+- [x] Docker Compose configuration (single-container production)
 - [x] Single-container deploy script (`scripts/deploy.sh`) with `--no-deps` + health-gate (brief restart blip)
 - [x] Health check endpoints for all services
 - [x] VPS setup complete (user, ports, SSH config)
@@ -732,7 +731,7 @@ console.log(pods);
 - [x] **Dec 13**: Go live at pulse.rectorspace.com
 - [x] **Dec 15**: Documentation finalized + Screenshots captured
 - [x] **Dec 15**: Submission document prepared (docs/SUBMISSION.md)
-- [ ] **Dec 26**: Submit before 07:59 UTC deadline (READY TO SUBMIT)
+- [x] **Dec 26**: Submitted — 3rd place, $1,000 USDC
 
 **Post-Launch Improvements** (Technical Debt - Defer to after bounty):
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -262,13 +262,12 @@ Per Xandeum team (Discord, 2025-12-07):
 **Domain**: `pulse.rectorspace.com`
 **VPS**: 151.245.137.75 (rectorspace.com)
 
-| Service     | Port | Container Name        |
-| ----------- | ---- | --------------------- |
-| Web (Blue)  | 7000 | pnode-pulse-web-blue  |
-| Web (Green) | 7001 | pnode-pulse-web-green |
-| Staging     | 7002 | pnode-pulse-staging   |
-| PostgreSQL  | 5434 | pnode-pulse-postgres  |
-| Redis       | 6381 | pnode-pulse-redis     |
+| Service          | Port          | Container Name        |
+| ---------------- | ------------- | --------------------- |
+| Web (Production) | 7001          | pnode-pulse-web-green |
+| Collector        | internal only | pnode-pulse-collector |
+| PostgreSQL       | internal only | pnode-pulse-postgres  |
+| Redis            | internal only | pnode-pulse-redis     |
 
 ---
 

--- a/docs/APM_SETUP.md
+++ b/docs/APM_SETUP.md
@@ -13,6 +13,7 @@ Application Performance Monitoring (APM) and error tracking provide critical vis
 ### Why APM?
 
 **Without APM** (current state):
+
 - ❌ Errors only visible in console logs (requires SSH)
 - ❌ No alerting when errors spike
 - ❌ No stack traces or context
@@ -20,6 +21,7 @@ Application Performance Monitoring (APM) and error tracking provide critical vis
 - ❌ Slow debugging (manual log inspection)
 
 **With APM** (after setup):
+
 - ✅ Real-time error notifications
 - ✅ Full stack traces with source maps
 - ✅ User context and breadcrumbs
@@ -32,6 +34,7 @@ Application Performance Monitoring (APM) and error tracking provide critical vis
 ## Recommended Service: Sentry
 
 **Why Sentry?**
+
 - Free tier (5K events/month)
 - Excellent Next.js support (@sentry/nextjs)
 - Source map support for readable stack traces
@@ -39,6 +42,7 @@ Application Performance Monitoring (APM) and error tracking provide critical vis
 - Performance monitoring included
 
 **Alternatives**:
+
 - **Datadog**: Full observability platform (expensive, $$$)
 - **New Relic**: Comprehensive APM (complex setup)
 - **LogRocket**: Session replay focus (frontend-heavy)
@@ -70,6 +74,7 @@ npx @sentry/wizard@latest -i nextjs
 ```
 
 **Wizard will prompt for**:
+
 - DSN (from Sentry project settings)
 - Upload source maps? **Yes**
 - Create example page? **No** (we'll integrate manually)
@@ -88,6 +93,7 @@ SENTRY_PROJECT=pnode-pulse
 ```
 
 **Where to find these**:
+
 - **DSN**: Sentry project settings → Client Keys (DSN)
 - **Auth Token**: Sentry account → Settings → Auth Tokens → Create New Token
   - Scopes needed: `project:releases`, `org:read`
@@ -99,32 +105,26 @@ Update `docker-compose.yml` to pass Sentry env vars:
 
 ```yaml
 services:
-  blue:
+  green:
     environment:
       # Existing vars...
       SENTRY_DSN: ${SENTRY_DSN}
       NEXT_PUBLIC_SENTRY_DSN: ${NEXT_PUBLIC_SENTRY_DSN}
       SENTRY_ENVIRONMENT: production
       SENTRY_RELEASE: ${GIT_COMMIT_SHA:-latest}
-
-  staging:
-    environment:
-      # Existing vars...
-      SENTRY_DSN: ${SENTRY_DSN}
-      NEXT_PUBLIC_SENTRY_DSN: ${NEXT_PUBLIC_SENTRY_DSN}
-      SENTRY_ENVIRONMENT: staging
-      SENTRY_RELEASE: ${GIT_COMMIT_SHA:-dev}
 ```
 
 ### Step 5: Verify Installation
 
 The wizard creates these files (review them):
+
 - `sentry.client.config.ts` - Client-side configuration
 - `sentry.server.config.ts` - Server-side configuration
 - `sentry.edge.config.ts` - Edge runtime configuration
 - `next.config.js` - Updated with Sentry webpack plugin
 
 **Check configuration**:
+
 ```typescript
 // sentry.server.config.ts should have:
 import * as Sentry from "@sentry/nextjs";
@@ -132,10 +132,10 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   environment: process.env.NODE_ENV,
-  
+
   // Performance Monitoring
   tracesSampleRate: 0.1, // 10% of transactions
-  
+
   // Session Replay (debugging)
   replaysSessionSampleRate: 0.1, // 10% of sessions
   replaysOnErrorSampleRate: 1.0, // 100% when errors occur
@@ -168,7 +168,7 @@ try {
       userId: ctx.session?.user?.id,
     },
   });
-  
+
   throw new TRPCError({
     code: "INTERNAL_SERVER_ERROR",
     message: error instanceof Error ? error.message : "Unknown error",
@@ -190,8 +190,8 @@ export async function runCollection() {
       tags: { worker: "collector" },
       extra: { nodesPolled: addresses.length },
     });
-    
-    logger.error('Collection failed', error);
+
+    logger.error("Collection failed", error);
     throw error;
   }
 }
@@ -245,16 +245,19 @@ try {
 2. **Create Alert Rule**:
 
 **Rule 1: Error Spike**
+
 - Condition: >10 errors in 5 minutes
 - Action: Email team
 - Environment: production
 
 **Rule 2: New Error Type**
+
 - Condition: First seen error
 - Action: Slack notification (if configured)
 - Environment: production
 
 **Rule 3: Performance Degradation**
+
 - Condition: p95 latency >2 seconds
 - Action: Email
 - Environment: production
@@ -290,11 +293,12 @@ module.exports = withSentryConfig(
     transpileClientSDK: true,
     hideSourceMaps: true, // Hides source maps from browser DevTools
     disableLogger: true,
-  }
+  },
 );
 ```
 
 **Verification**:
+
 1. Deploy to production
 2. Trigger an error
 3. Check Sentry issue - stack trace should show TypeScript code, not minified JS
@@ -316,7 +320,8 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 ```
 
 **Test**:
-1. Deploy to staging
+
+1. Deploy to production
 2. Visit `/api/sentry-test`
 3. Check Sentry dashboard for error
 4. Verify stack trace is readable
@@ -381,10 +386,12 @@ Sentry.init({
 ## Cost Management
 
 **Free Tier Limits**:
+
 - 5,000 errors/month
 - 10,000 performance transactions/month
 
 **Staying Within Free Tier**:
+
 1. **Sample Performance**: Set `tracesSampleRate: 0.1` (10%)
 2. **Filter Noisy Errors**: Ignore known issues in Sentry dashboard
 3. **Monitor Usage**: Check Sentry → Stats → Usage
@@ -399,10 +406,9 @@ Sentry.init({
 - [ ] Run Sentry wizard (`npx @sentry/wizard`)
 - [ ] Add environment variables to `.env`
 - [ ] Update `docker-compose.yml` with Sentry env vars
-- [ ] Deploy to staging and test
 - [ ] Configure alert rules in Sentry
 - [ ] (Optional) Setup Slack integration
-- [ ] Deploy to production
+- [ ] Deploy to production and test
 - [ ] Monitor error dashboard for 24 hours
 - [ ] Document in runbook
 
@@ -411,17 +417,20 @@ Sentry.init({
 ## Troubleshooting
 
 **Errors not appearing in Sentry**:
+
 - Check `SENTRY_DSN` is set correctly
 - Verify Sentry init in both client and server configs
 - Check browser console for Sentry errors
 - Ensure source maps uploaded successfully
 
 **Source maps not working**:
+
 - Verify `SENTRY_AUTH_TOKEN` has correct scopes
 - Check `next.config.js` Sentry configuration
 - Look for source map upload errors in build logs
 
 **Too many errors logged**:
+
 - Add filters in Sentry (Settings → Inbound Filters)
 - Ignore patterns: `/healthcheck/`, browser extensions
 - Reduce sample rate if hitting free tier limit

--- a/docs/DATABASE_BACKUP.md
+++ b/docs/DATABASE_BACKUP.md
@@ -8,11 +8,11 @@ pNode Pulse uses PostgreSQL with TimescaleDB extension for time-series data. Thi
 
 ### Schedule & Retention
 
-| Frequency | Retention | Storage Location |
-|-----------|-----------|------------------|
-| **Daily** | 30 days | `/backups/pnode-pulse` on VPS |
-| **Weekly** | 90 days | S3 (optional, off-site) |
-| **Monthly** | 1 year | S3 Glacier (optional, archival) |
+| Frequency   | Retention | Storage Location                |
+| ----------- | --------- | ------------------------------- |
+| **Daily**   | 30 days   | `/backups/pnode-pulse` on VPS   |
+| **Weekly**  | 90 days   | S3 (optional, off-site)         |
+| **Monthly** | 1 year    | S3 Glacier (optional, archival) |
 
 **Backup Time**: 2:00 AM UTC daily (scheduled via cron)
 
@@ -106,8 +106,9 @@ cd ~/pnode-pulse
 ```
 
 The script will:
+
 1. ✋ **Prompt for confirmation** (destructive operation)
-2. 🛑 **Stop application** (blue/green/staging containers)
+2. 🛑 **Stop the application** (`green` container)
 3. 🗑️ **Drop existing objects** (`--clean --if-exists`)
 4. 📥 **Restore from backup**
 5. ✅ **Verify restoration** (count nodes and metrics)
@@ -159,6 +160,7 @@ fi
 ### Alerting
 
 Configure alerts for:
+
 - Backup fails to complete (cron sends email on error)
 - Backup file size anomaly (too small = incomplete backup)
 - No backup in 26 hours (missed schedule)
@@ -173,6 +175,7 @@ Configure alerts for:
 **Symptoms**: Application errors, query failures, data inconsistencies
 
 **Recovery**:
+
 1. Stop application immediately
 2. Backup corrupted database (if possible): `pg_dump -Fc > corrupted_backup.dump`
 3. Restore from last known good backup
@@ -187,10 +190,11 @@ Configure alerts for:
 **Symptoms**: Missing nodes, metrics, or other data
 
 **Recovery**:
+
 1. **DO NOT** run any DELETE or UPDATE queries
 2. Immediately create backup of current state
-3. Restore to staging environment from most recent backup
-4. Extract deleted data from staging backup
+3. Restore the most recent backup into a scratch / restore-test database
+4. Extract deleted data from the restore-test database
 5. Manually re-insert into production (or full restore if extensive)
 
 **RTO**: ~1-4 hours  
@@ -201,6 +205,7 @@ Configure alerts for:
 **Symptoms**: VPS unreachable, hardware failure
 
 **Recovery**:
+
 1. Provision new VPS
 2. Setup Docker, PostgreSQL, Redis
 3. Download latest backup from S3 (if configured) or copy from local storage
@@ -219,12 +224,12 @@ Off-site backups provide geographic redundancy and protection against VPS failur
 
 ### Supported Providers
 
-| Provider | Endpoint | Cost (approx.) |
-|----------|----------|----------------|
-| **AWS S3** | (default) | $0.023/GB/month |
-| **Backblaze B2** | `s3.REGION.backblazeb2.com` | $0.005/GB/month |
-| **Wasabi** | `s3.REGION.wasabisys.com` | $0.007/GB/month |
-| **MinIO** | Self-hosted | Free (self-hosted) |
+| Provider         | Endpoint                    | Cost (approx.)     |
+| ---------------- | --------------------------- | ------------------ |
+| **AWS S3**       | (default)                   | $0.023/GB/month    |
+| **Backblaze B2** | `s3.REGION.backblazeb2.com` | $0.005/GB/month    |
+| **Wasabi**       | `s3.REGION.wasabisys.com`   | $0.007/GB/month    |
+| **MinIO**        | Self-hosted                 | Free (self-hosted) |
 
 ### Quick Setup (Interactive)
 
@@ -237,6 +242,7 @@ cd ~/pnode-pulse
 ```
 
 This will:
+
 1. Install AWS CLI if needed
 2. Guide you through provider selection
 3. Configure credentials
@@ -256,12 +262,14 @@ apt install awscli
 #### 2. Configure Credentials
 
 **Option A: AWS Configure (interactive)**
+
 ```bash
 aws configure
 # Enter: Access Key ID, Secret Access Key, Region, Output format
 ```
 
 **Option B: Environment Variables**
+
 ```bash
 export AWS_ACCESS_KEY_ID="your-access-key"
 export AWS_SECRET_ACCESS_KEY="your-secret-key"
@@ -350,27 +358,27 @@ s3://pnode-pulse-backups/
 
 ### Retention Policy
 
-| Storage | Retention | Managed By |
-|---------|-----------|------------|
-| Local (`/backups/`) | 30 days | `backup-db.sh` (RETENTION_DAYS) |
-| S3 | 90 days | `backup-db.sh` (S3_RETENTION_DAYS) |
-| S3 Glacier | 1 year | AWS Lifecycle Rules (manual setup) |
+| Storage             | Retention | Managed By                         |
+| ------------------- | --------- | ---------------------------------- |
+| Local (`/backups/`) | 30 days   | `backup-db.sh` (RETENTION_DAYS)    |
+| S3                  | 90 days   | `backup-db.sh` (S3_RETENTION_DAYS) |
+| S3 Glacier          | 1 year    | AWS Lifecycle Rules (manual setup) |
 
 ### Storage Classes
 
-| Class | Use Case | Retrieval Time | Cost |
-|-------|----------|----------------|------|
-| **STANDARD** | Latest backup only | Instant | Higher |
-| **STANDARD_IA** | Daily backups (default) | Instant | Lower |
-| **GLACIER** | Monthly archives | Hours | Lowest |
+| Class           | Use Case                | Retrieval Time | Cost   |
+| --------------- | ----------------------- | -------------- | ------ |
+| **STANDARD**    | Latest backup only      | Instant        | Higher |
+| **STANDARD_IA** | Daily backups (default) | Instant        | Lower  |
+| **GLACIER**     | Monthly archives        | Hours          | Lowest |
 
 ### Cost Estimate
 
-| Data Volume | S3 Standard-IA | Backblaze B2 | Wasabi |
-|-------------|----------------|--------------|--------|
-| 1 GB | $0.02/month | $0.005/month | $0.007/month |
-| 10 GB | $0.23/month | $0.05/month | $0.07/month |
-| 100 GB | $2.30/month | $0.50/month | $0.70/month |
+| Data Volume | S3 Standard-IA | Backblaze B2 | Wasabi       |
+| ----------- | -------------- | ------------ | ------------ |
+| 1 GB        | $0.02/month    | $0.005/month | $0.007/month |
+| 10 GB       | $0.23/month    | $0.05/month  | $0.07/month  |
+| 100 GB      | $2.30/month    | $0.50/month  | $0.70/month  |
 
 ### Verify S3 Backups
 
@@ -396,9 +404,9 @@ rm /tmp/verify.dump
 
 ### Quarterly Restore Test
 
-1. **Setup test environment** (staging database)
+1. **Setup test environment** (restore-test database)
 2. **Select random backup** from last 30 days
-3. **Restore to staging**
+3. **Restore to the restore-test database**
 4. **Verify data integrity**: Check row counts, recent data
 5. **Test application**: Ensure queries work, UI loads
 6. **Document results**: Note any issues, update procedures
@@ -412,14 +420,14 @@ rm /tmp/verify.dump
 BACKUP_FILE=$(ls -t /backups/pnode-pulse/*.dump | shuf -n 1)
 echo "Testing restore of: $BACKUP_FILE"
 
-# Restore to staging database
+# Restore to restore-test database
 PGPASSWORD=$POSTGRES_PASSWORD pg_restore \
-  -h localhost -p 5435 -U pnodepulse -d pnodepulse_staging \
+  -h localhost -p 5435 -U pnodepulse -d pnodepulse_restore_test \
   --clean --if-exists \
   "$BACKUP_FILE"
 
 # Verify
-PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -p 5435 -U pnodepulse -d pnodepulse_staging -c "
+PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -p 5435 -U pnodepulse -d pnodepulse_restore_test -c "
   SELECT 'Nodes: ' || COUNT(*) FROM nodes;
   SELECT 'Metrics: ' || COUNT(*) FROM node_metrics;
 "

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -31,13 +31,13 @@ ssh pnodepulse
 docker compose ps
 
 # View logs
-docker compose logs -f blue --tail 100
+docker compose logs -f green --tail 100
 
 # Health check
-curl http://localhost:7000/api/health
+curl http://localhost:7001/api/health
 
 # Restart services
-docker compose restart blue
+docker compose restart green
 
 # Database backup
 ./scripts/backup-db.sh
@@ -48,11 +48,11 @@ docker compose restart blue
 
 ### Service Ports
 
-| Service                | Port | URL                           |
-| ---------------------- | ---- | ----------------------------- |
-| **Green (Production)** | 7001 | https://pulse.rectorspace.com |
-| **PostgreSQL**         | 5434 | localhost only                |
-| **Redis**              | 6381 | localhost only                |
+| Service                | Port          | URL / Access                     |
+| ---------------------- | ------------- | -------------------------------- |
+| **Green (Production)** | 7001 (host)   | https://pulse.rectorspace.com    |
+| **PostgreSQL**         | internal only | `postgres:5432` (Docker network) |
+| **Redis**              | internal only | `redis:6379` (Docker network)    |
 
 ### Contact Information
 
@@ -80,14 +80,14 @@ Deployment is fully automated via GitHub Actions on merge to `main` branch.
 **Deployment Steps** (automated):
 
 1. Build Docker image from `main` branch
-2. Push image to GHCR with `:latest` tag
-3. SSH to VPS
-4. Pull new image
-5. Execute blue/green deployment (zero downtime)
-6. Run health checks
-7. Notify in Slack (if configured)
+2. Push image to GHCR with `:latest` + `:prod-<sha>` tags (the SHA tag enables rollback)
+3. SSH to VPS (via Cloudflare Tunnel `ssh.rectorspace.com`)
+4. `git pull origin main`, then `bash scripts/deploy.sh`
+5. Run `scripts/deploy.sh` — single-container recreate of `green` (`docker compose pull green` → `docker compose up -d --no-deps green`), health-gated (up to 120s; the workflow fails if `green` never becomes healthy). Brief ~5–15s restart blip (NOT zero-downtime)
+6. Post-deploy smoke test curls ~9 public endpoints to confirm the live site responds
+7. `docker image prune -f`, then verify (`docker compose ps green` + recent logs)
 
-**Timeline**: ~10-15 minutes from merge to live
+**Timeline**: ~3-5 minutes from merge to live
 
 ### Manual Deployment
 
@@ -104,57 +104,45 @@ ssh pnodepulse
 # Navigate to project directory
 cd ~/pnode-pulse
 
-# Pull latest images
-docker compose pull blue
+# Pull the latest code (deploy.sh + compose definitions)
+git pull origin main
 
-# Deploy blue (production)
-docker compose up -d blue
+# Run the single-container deploy (pulls the image, recreates ONLY green
+# with --no-deps, then health-gates green for up to 120s)
+bash scripts/deploy.sh
 
-# Wait 10 seconds for health check
-sleep 10
+# Equivalent manual steps if you prefer to run them by hand:
+#   docker compose pull green
+#   docker compose up -d --no-deps green   # --no-deps leaves postgres/redis/collector untouched
 
-# Verify health
-curl -f http://localhost:7000/api/health || echo "⚠️  Health check failed"
+# Verify health (deploy.sh already health-gates; this is a sanity check)
+curl -f http://localhost:7001/api/health || echo "⚠️  Health check failed"
 
 # Check logs
-docker compose logs -f blue --tail 50
+docker compose logs -f green --tail 50
 ```
 
-### Blue/Green Deployment
+### Single-Container Deploy
 
-Zero-downtime deployment using blue/green strategy:
+Production runs **one** web container named `green` on host port 7001 (container port 3000). nginx points **permanently** at `localhost:7001` — there is no upstream switching, no `blue` container, no port 7000. A deploy recreates only `green`; `postgres`, `redis`, and the `collector` worker are long-lived and never touched by a deploy.
 
 ```bash
 # SSH to VPS
 ssh pnodepulse
 cd ~/pnode-pulse
 
-# Determine active environment
-ACTIVE=$(docker compose ps --filter "status=running" | grep "7000" | grep -q "blue" && echo "blue" || echo "green")
-INACTIVE=$([ "$ACTIVE" = "blue" ] && echo "green" || echo "blue")
-
-echo "Active: $ACTIVE, Deploying to: $INACTIVE"
-
-# Pull latest image
-docker compose pull $INACTIVE
-
-# Start inactive environment
-docker compose up -d $INACTIVE
-
-# Wait for health check
-sleep 15
-curl -f http://localhost:7001/api/health || exit 1
-
-# Switch nginx upstream (manual step - update nginx config)
-# sudo nano /etc/nginx/sites-available/pulse.rectorspace.com
-# Change upstream from 7000 to 7001 (or vice versa)
-# sudo nginx -t && sudo systemctl reload nginx
-
-# Stop old environment
-docker compose stop $ACTIVE
-
-echo "✓ Deployment complete: $INACTIVE is now active"
+# Pull the latest code, then run the deploy script
+git pull origin main
+bash scripts/deploy.sh
 ```
+
+`scripts/deploy.sh` does the following:
+
+1. `docker compose pull green` — fetch the new image.
+2. `docker compose up -d --no-deps green` — recreate ONLY the `green` web container (`--no-deps` leaves `postgres`/`redis`/`collector` running).
+3. Health-gate `green`: poll its container healthcheck for up to 120s. If it never reports `healthy`, the script exits non-zero (the deploy is considered failed — roll back).
+
+Because the single container is recreated in place, expect a brief ~5–15s restart blip (this is NOT a zero-downtime deploy). nginx needs no changes — the upstream is fixed at `localhost:7001`.
 
 ### Database Migrations
 
@@ -166,13 +154,13 @@ ssh pnodepulse
 cd ~/pnode-pulse
 
 # View pending migrations
-docker compose exec blue npx prisma migrate status
+docker compose exec green npx prisma migrate status
 
 # Apply migrations (non-interactive)
-docker compose exec blue npx prisma migrate deploy
+docker compose exec green npx prisma migrate deploy
 
 # Verify
-docker compose exec blue npx prisma migrate status
+docker compose exec green npx prisma migrate status
 # Should show: "Database is up to date"
 ```
 
@@ -186,30 +174,28 @@ docker compose exec blue npx prisma migrate status
 
 **Steps**:
 
+Rollback = re-deploy a known-good image. Every production build pushes a `:prod-<sha>` tag to GHCR specifically for this. There is no environment switch — you re-tag the good image as `:latest` and re-run the deploy.
+
 ```bash
 # SSH to VPS
 ssh pnodepulse
 cd ~/pnode-pulse
 
-# Option 1: Quick switch to inactive environment (if still running)
-docker compose start green  # or blue
-# Update nginx upstream back to previous port
-
-# Option 2: Rollback to specific Docker image
-# List recent image tags
+# List recent image tags to pick a known-good build
 docker images ghcr.io/rector-labs/pnode-pulse --format "table {{.Tag}}\t{{.CreatedAt}}"
 
-# Pull specific version (use git SHA from GitHub)
-docker pull ghcr.io/rector-labs/pnode-pulse:abc1234567890def
+# Pull the known-good production image (use its prod-<sha> tag)
+docker pull ghcr.io/rector-labs/pnode-pulse:prod-<sha>
 
-# Tag as latest locally
-docker tag ghcr.io/rector-labs/pnode-pulse:abc1234567890def ghcr.io/rector-labs/pnode-pulse:latest
+# Re-tag it as :latest locally (deploy.sh deploys whatever :latest points to)
+docker tag ghcr.io/rector-labs/pnode-pulse:prod-<sha> ghcr.io/rector-labs/pnode-pulse:latest
 
-# Restart with old image
-docker compose up -d blue
+# Recreate green from :latest (single-container, health-gated)
+SERVICE=green bash scripts/deploy.sh
+# (equivalently: docker compose up -d --no-deps green)
 
 # Verify
-curl -f http://localhost:7000/api/health
+curl -f http://localhost:7001/api/health
 ```
 
 **Timeline**: 2-5 minutes
@@ -222,7 +208,7 @@ curl -f http://localhost:7000/api/health
 
 ```bash
 # If migration just ran and caused immediate issues
-docker compose exec blue npx prisma migrate resolve --rolled-back 20251209_migration_name
+docker compose exec green npx prisma migrate resolve --rolled-back 20251209_migration_name
 
 # Restore application to previous version (without migration)
 ```
@@ -311,7 +297,7 @@ docker compose exec postgres psql -U pnodepulse -c "
 docker compose ps
 
 # Check logs for errors
-docker compose logs blue --tail 100
+docker compose logs green --tail 100
 
 # Check disk space
 df -h
@@ -320,7 +306,7 @@ df -h
 free -h
 
 # Restart service
-docker compose restart blue
+docker compose restart green
 
 # Full restart (if needed)
 docker compose down
@@ -379,7 +365,7 @@ docker compose restart redis
 
 ```bash
 # Check application logs
-docker compose logs blue --tail 200 | grep ERROR
+docker compose logs green --tail 200 | grep ERROR
 
 # Check nginx logs (if applicable)
 sudo tail -f /var/log/nginx/error.log
@@ -388,10 +374,10 @@ sudo tail -f /var/log/nginx/error.log
 docker stats
 
 # Check health endpoint
-curl -v http://localhost:7000/api/health
+curl -v http://localhost:7001/api/health
 
 # Restart application
-docker compose restart blue
+docker compose restart green
 ```
 
 ### High CPU/Memory Usage
@@ -404,13 +390,13 @@ docker stats
 htop  # or top
 
 # Check specific processes
-docker compose exec blue ps aux | head -20
+docker compose exec green ps aux | head -20
 
 # Restart high-usage container
-docker compose restart blue
+docker compose restart green
 
 # Check for memory leaks (if persistent)
-docker compose logs blue | grep "out of memory"
+docker compose logs green | grep "out of memory"
 ```
 
 ### Disk Space Full
@@ -422,8 +408,10 @@ df -h
 # Find large files
 du -h / | sort -rh | head -20
 
-# Clean up Docker images/containers
-docker system prune -a --volumes
+# Clean up dangling Docker images + build cache
+# (shared VPS: NEVER `docker system prune` — it would wipe other projects' images/volumes)
+docker image prune -f
+docker builder prune -f
 
 # Clean up old backups (if needed)
 find /backups/pnode-pulse/ -name "*.dump" -mtime +30 -delete
@@ -441,7 +429,7 @@ sudo journalctl --vacuum-time=7d
 **Application Health**:
 
 ```bash
-curl http://localhost:7000/api/health
+curl http://localhost:7001/api/health
 # Expected: {"status":"ok","timestamp":"..."}
 ```
 
@@ -465,13 +453,13 @@ docker compose exec redis redis-cli ping
 
 ```bash
 # Application
-docker compose logs -f blue --tail 100
+docker compose logs -f green --tail 100
 
 # All services
 docker compose logs -f --tail 50
 
 # Specific time range
-docker compose logs --since 30m blue
+docker compose logs --since 30m green
 ```
 
 **System Metrics**:
@@ -508,8 +496,8 @@ External monitoring checks your site from outside, detecting when it's completel
 **When Alert Fires**:
 
 1. Check health endpoint: `curl -s https://pulse.rectorspace.com/api/health`
-2. SSH and check logs: `ssh pnodepulse && docker compose logs blue --tail 100`
-3. Restart if needed: `docker compose restart blue`
+2. SSH and check logs: `ssh pnodepulse && docker compose logs green --tail 100`
+3. Restart if needed: `docker compose restart green`
 4. Check Sentry for related errors
 
 ### APM & Error Tracking
@@ -603,7 +591,7 @@ Recommended alerts:
 
 4. **Verify restoration**:
    ```bash
-   curl http://localhost:7000/api/health
+   curl http://localhost:7001/api/health
    # Check critical data in UI
    ```
 

--- a/docs/SUBMISSION.md
+++ b/docs/SUBMISSION.md
@@ -76,16 +76,16 @@ Production-ready analytics platform tracking 200+ pNodes with real-time metrics,
 
 ### Innovation Features (Bonus)
 
-| Feature                  | Description                                                    |
-| ------------------------ | -------------------------------------------------------------- |
-| **TimescaleDB**          | Time-series database for efficient metrics storage and queries |
-| **Health Scoring**       | Multi-factor A-F grades based on CPU, RAM, uptime              |
-| **IP Change Detection**  | Tracks nodes by pubkey, detects IP migrations                  |
-| **Node Graveyard**       | Historical archive of inactive/offline nodes                   |
-| **Capacity Projections** | Growth forecasting based on historical trends                  |
-| **Embeddable Badges**    | SVG badges for external sites (network.svg, storage.svg)       |
-| **Public REST API**      | Full API access for third-party integrations                   |
-| **Blue/Green Deploy**    | Zero-downtime production deployments                           |
+| Feature                     | Description                                                    |
+| --------------------------- | -------------------------------------------------------------- |
+| **TimescaleDB**             | Time-series database for efficient metrics storage and queries |
+| **Health Scoring**          | Multi-factor A-F grades based on CPU, RAM, uptime              |
+| **IP Change Detection**     | Tracks nodes by pubkey, detects IP migrations                  |
+| **Node Graveyard**          | Historical archive of inactive/offline nodes                   |
+| **Capacity Projections**    | Growth forecasting based on historical trends                  |
+| **Embeddable Badges**       | SVG badges for external sites (network.svg, storage.svg)       |
+| **Public REST API**         | Full API access for third-party integrations                   |
+| **Single-Container Deploy** | Health-gated push-to-deploy on `main` with rollback            |
 
 ---
 

--- a/docs/UPTIME_MONITORING.md
+++ b/docs/UPTIME_MONITORING.md
@@ -112,18 +112,6 @@ This monitor validates:
 - Expected Status Codes: 200
 - Keyword: `nodes` (type: exists)
 
-#### Monitor 4: Staging Environment
-
-| Setting             | Value                                              |
-| ------------------- | -------------------------------------------------- |
-| Monitor Type        | HTTP(s)                                            |
-| Friendly Name       | pNode Pulse - Staging                              |
-| URL                 | `https://staging.pulse.rectorspace.com/api/health` |
-| Monitoring Interval | 15 minutes                                         |
-| Monitor Timeout     | 30 seconds                                         |
-
-**Note**: Longer interval for staging (less critical).
-
 ### Step 3: Configure Alert Contacts
 
 Go to **My Settings** → **Alert Contacts** → **Add Alert Contact**
@@ -271,7 +259,6 @@ To use `status.pulse.rectorspace.com`:
 - **Homepage**: User-facing availability
 - **Health endpoint**: Application + dependencies
 - **Critical API**: Core functionality (leaderboard, nodes)
-- **Staging**: Pre-production validation
 
 ### 2. Set Appropriate Intervals
 
@@ -280,7 +267,6 @@ To use `status.pulse.rectorspace.com`:
 | Production homepage | 5 min    | Critical user experience |
 | Production health   | 5 min    | Early warning system     |
 | Production API      | 5 min    | Core functionality       |
-| Staging             | 15 min   | Less critical            |
 
 ### 3. Configure Escalation
 
@@ -311,11 +297,11 @@ Set up tiered alerting:
    ```bash
    ssh pnodepulse
    docker compose ps
-   docker compose logs --tail=100 blue
+   docker compose logs --tail=100 green
    ```
 4. **Restart if needed**:
    ```bash
-   docker compose restart blue
+   docker compose restart green
    ```
 5. **Document incident** in runbook/post-mortem
 
@@ -323,7 +309,7 @@ Set up tiered alerting:
 
 | Alert            | Likely Cause      | Fix                            |
 | ---------------- | ----------------- | ------------------------------ |
-| Homepage down    | Container crashed | `docker compose up -d blue`    |
+| Homepage down    | Container crashed | `docker compose up -d green`   |
 | Health degraded  | Redis down        | `docker compose restart redis` |
 | Health unhealthy | Database down     | Check PostgreSQL logs          |
 | API timeout      | High load         | Scale or optimize queries      |
@@ -351,7 +337,6 @@ When UptimeRobot detects downtime:
 - [ ] Add homepage monitor (HTTPS)
 - [ ] Add health endpoint monitor
 - [ ] Add API endpoint monitor
-- [ ] Add staging monitor
 - [ ] Configure email alert contact
 - [ ] Configure Discord/Slack webhook
 - [ ] Test alerts (pause/resume monitor)

--- a/docs/production-readiness-report.md
+++ b/docs/production-readiness-report.md
@@ -41,12 +41,14 @@ Legal & Compliance   ████████░░ 8/10
 ### 1. Security Audit ████████░░ 8/10 (was 6/10)
 
 **Improvements Since Last Report**:
+
 - ✅ JWT secret defaults removed (now requires env var)
 - ✅ Health check endpoint added
 - ✅ CORS headers configured in next.config.ts
 - ✅ Security headers added (X-Content-Type-Options, X-Frame-Options, X-XSS-Protection)
 
 **Strengths**:
+
 - ✅ Hardcoded secrets check: No API keys or passwords found in source code
 - ✅ `.gitignore` properly excludes `.env`, `.env.local`, `.env.*.local`
 - ✅ JWT authentication implemented with proper signature verification (`jose` library)
@@ -61,19 +63,21 @@ Legal & Compliance   ████████░░ 8/10
 
 **Issues Found**:
 
-| Severity | Issue | Location |
-|----------|-------|----------|
-| 🟡 Medium | 13 npm vulnerabilities (6 high, 7 moderate) | `npm audit` |
-| 🟡 Medium | CORS allows all origins for /api/v1/* | `next.config.ts:133` |
-| 🟡 Medium | No explicit CSP header for main pages | `next.config.ts` |
-| 🟢 Low | API key in query param supported | `rate-limiter.ts:131` |
+| Severity  | Issue                                       | Location              |
+| --------- | ------------------------------------------- | --------------------- |
+| 🟡 Medium | 13 npm vulnerabilities (6 high, 7 moderate) | `npm audit`           |
+| 🟡 Medium | CORS allows all origins for /api/v1/\*      | `next.config.ts:133`  |
+| 🟡 Medium | No explicit CSP header for main pages       | `next.config.ts`      |
+| 🟢 Low    | API key in query param supported            | `rate-limiter.ts:131` |
 
 **npm vulnerabilities breakdown**:
+
 - `d3-color` ReDoS (high) - via react-simple-maps
 - `vite` moderate vulnerabilities - dev dependency only
 - `vitest` moderate vulnerabilities - dev dependency only
 
 **Recommendations**:
+
 1. Run `npm audit fix` or update react-simple-maps
 2. Restrict CORS origins to known domains for production
 3. Add Content-Security-Policy header for main routes
@@ -84,13 +88,15 @@ Legal & Compliance   ████████░░ 8/10
 ### 2. Environment Configuration █████████░ 9/10 (was 8/10)
 
 **Improvements Since Last Report**:
+
 - ✅ JWT_SECRET now documented in .env.example
 - ✅ All production variables documented
 - ✅ Instructions for secure secret generation added
 
 **Strengths**:
+
 - ✅ `.env.example` template exists with all required variables documented
-- ✅ Clear separation between dev/staging/prod configurations
+- ✅ Clear separation between dev/prod configurations
 - ✅ Secrets via environment variables (DATABASE_URL, JWT_SECRET, ADMIN_API_KEY)
 - ✅ Redis URL configurable via REDIS_URL environment variable
 - ✅ Seed nodes configurable via PRPC_SEED_NODES
@@ -99,11 +105,12 @@ Legal & Compliance   ████████░░ 8/10
 
 **Issues Found**:
 
-| Severity | Issue | Location |
-|----------|-------|----------|
-| 🟢 Low | Missing LOG_LEVEL documentation | `.env.example` |
+| Severity | Issue                           | Location       |
+| -------- | ------------------------------- | -------------- |
+| 🟢 Low   | Missing LOG_LEVEL documentation | `.env.example` |
 
 **Recommendations**:
+
 1. Add LOG_LEVEL to .env.example with options (debug, info, warn, error)
 2. Consider using a secrets manager for production (HashiCorp Vault, AWS Secrets Manager)
 
@@ -112,6 +119,7 @@ Legal & Compliance   ████████░░ 8/10
 ### 3. Error Handling & Logging ███████░░░ 7/10
 
 **Strengths**:
+
 - ✅ Custom Logger class with log levels (debug, info, warn, error)
 - ✅ Environment-aware log level defaults (production=info, dev=debug)
 - ✅ Structured logging with timestamps and JSON context
@@ -121,14 +129,15 @@ Legal & Compliance   ████████░░ 8/10
 
 **Issues Found**:
 
-| Severity | Issue | Location |
-|----------|-------|----------|
-| 🔴 High | No external error tracking (Sentry not integrated) | N/A |
-| 🟡 Medium | Logger uses console.log/warn/error only | `src/lib/logger.ts` |
-| 🟡 Medium | No request ID tracing for debugging | N/A |
-| 🟢 Low | No log aggregation configured | N/A |
+| Severity  | Issue                                              | Location            |
+| --------- | -------------------------------------------------- | ------------------- |
+| 🔴 High   | No external error tracking (Sentry not integrated) | N/A                 |
+| 🟡 Medium | Logger uses console.log/warn/error only            | `src/lib/logger.ts` |
+| 🟡 Medium | No request ID tracing for debugging                | N/A                 |
+| 🟢 Low    | No log aggregation configured                      | N/A                 |
 
 **Recommendations**:
+
 1. **CRITICAL**: Integrate Sentry before production launch (see `docs/APM_SETUP.md`)
 2. Consider upgrading to pino for production-grade logging
 3. Add request ID headers for distributed tracing
@@ -139,6 +148,7 @@ Legal & Compliance   ████████░░ 8/10
 ### 4. Performance & Optimization █████████░ 9/10
 
 **Strengths**:
+
 - ✅ Next.js standalone output for optimized Docker builds
 - ✅ Bundle analyzer configured (`ANALYZE=true npm run build`)
 - ✅ Image optimization with AVIF/WebP formats
@@ -154,12 +164,13 @@ Legal & Compliance   ████████░░ 8/10
 
 **Issues Found**:
 
-| Severity | Issue | Location |
-|----------|-------|----------|
-| 🟢 Low | No explicit service worker for offline support | N/A |
-| 🟢 Low | PWA manifest caching only 24h | `next.config.ts:121` |
+| Severity | Issue                                          | Location             |
+| -------- | ---------------------------------------------- | -------------------- |
+| 🟢 Low   | No explicit service worker for offline support | N/A                  |
+| 🟢 Low   | PWA manifest caching only 24h                  | `next.config.ts:121` |
 
 **Recommendations**:
+
 1. Consider implementing service worker for offline dashboard
 2. Run bundle analysis and optimize large dependencies
 
@@ -168,11 +179,13 @@ Legal & Compliance   ████████░░ 8/10
 ### 5. Testing & Quality ███████░░░ 7/10 (was 4/10)
 
 **Improvements Since Last Report**:
+
 - ✅ Vitest test framework configured
 - ✅ Coverage tool added (`vitest --coverage`)
 - ✅ 9 test files created covering critical paths
 
 **Strengths**:
+
 - ✅ Test suite exists with Vitest
 - ✅ Coverage tool configured (`vitest --coverage`)
 - ✅ Unit tests for analytics, rate-limiter, validation, JWT, collector
@@ -181,6 +194,7 @@ Legal & Compliance   ████████░░ 8/10
 - ✅ TypeScript strict mode checks
 
 **Test Files Found (9)**:
+
 - `analytics/health-scorer.test.ts`
 - `analytics/statistics.test.ts`
 - `api/rate-limiter.test.ts`
@@ -193,13 +207,14 @@ Legal & Compliance   ████████░░ 8/10
 
 **Issues Found**:
 
-| Severity | Issue | Location |
-|----------|-------|----------|
-| 🟡 Medium | No E2E tests found | N/A |
-| 🟡 Medium | No pre-commit hooks (Husky) | N/A |
-| 🟢 Low | Coverage percentage unknown | Need to run `npm test:coverage` |
+| Severity  | Issue                       | Location                        |
+| --------- | --------------------------- | ------------------------------- |
+| 🟡 Medium | No E2E tests found          | N/A                             |
+| 🟡 Medium | No pre-commit hooks (Husky) | N/A                             |
+| 🟢 Low    | Coverage percentage unknown | Need to run `npm test:coverage` |
 
 **Recommendations**:
+
 1. Add E2E tests for critical user flows (Playwright/Cypress)
 2. Set up pre-commit hooks with Husky
 3. Target 70%+ code coverage for critical paths
@@ -210,32 +225,34 @@ Legal & Compliance   ████████░░ 8/10
 ### 6. Infrastructure & Deployment █████████░ 9/10 (was 8/10)
 
 **Improvements Since Last Report**:
+
 - ✅ Health check endpoint added (`/api/health`)
 - ✅ Graceful shutdown handling added
 - ✅ Rollback procedures documented in RUNBOOK.md
 
 **Strengths**:
+
 - ✅ Multi-stage Dockerfile with security best practices
 - ✅ Non-root user in production container
 - ✅ Docker Compose with explicit networks and volume names
-- ✅ Blue/green deployment support (ports 7000/7001)
-- ✅ Staging environment (port 7002)
+- ✅ Single-container production deploy (`green`, port 7001)
 - ✅ Health checks on all services
-- ✅ GitHub Actions CI/CD pipeline for staging and production
-- ✅ Zero-downtime deployment via blue-green strategy
+- ✅ GitHub Actions CI/CD pipeline for production (push-to-deploy on `main`)
+- ✅ Health-gated deploy with `:prod-<sha>` rollback (brief restart blip)
 - ✅ Container restart policies (`unless-stopped`)
 - ✅ Service dependencies with health conditions
 - ✅ Explicit network definitions preventing conflicts
 
 **Issues Found**:
 
-| Severity | Issue | Location |
-|----------|-------|----------|
-| 🟡 Medium | Collector service not in docker-compose.yml | `docker-compose.yml` |
-| 🟢 Low | No resource limits on containers | `docker-compose.yml` |
-| 🟢 Low | Redis persistence but no backup | `docker-compose.yml:36` |
+| Severity  | Issue                                       | Location                |
+| --------- | ------------------------------------------- | ----------------------- |
+| 🟡 Medium | Collector service not in docker-compose.yml | `docker-compose.yml`    |
+| 🟢 Low    | No resource limits on containers            | `docker-compose.yml`    |
+| 🟢 Low    | Redis persistence but no backup             | `docker-compose.yml:36` |
 
 **Recommendations**:
+
 1. Add collector service to docker-compose.yml or document separate startup
 2. Add resource limits (memory, CPU) to prevent resource exhaustion
 3. Add Redis backup to backup strategy
@@ -245,11 +262,13 @@ Legal & Compliance   ████████░░ 8/10
 ### 7. Database & Data ████████░░ 8/10
 
 **Improvements Since Last Report**:
+
 - ✅ Backup strategy documented (`docs/DATABASE_BACKUP.md`)
 - ✅ Backup scripts provided
 - ✅ Rollback procedures documented
 
 **Strengths**:
+
 - ✅ 11 database migrations versioned
 - ✅ TimescaleDB for time-series metrics
 - ✅ Connection pooling via Prisma
@@ -263,13 +282,14 @@ Legal & Compliance   ████████░░ 8/10
 
 **Issues Found**:
 
-| Severity | Issue | Location |
-|----------|-------|----------|
-| 🟡 Medium | Backup cron job may not be configured on VPS | VPS setup |
-| 🟡 Medium | No off-site backup (S3) implemented | `docs/DATABASE_BACKUP.md` |
-| 🟢 Low | TimescaleDB compression not verified | N/A |
+| Severity  | Issue                                        | Location                  |
+| --------- | -------------------------------------------- | ------------------------- |
+| 🟡 Medium | Backup cron job may not be configured on VPS | VPS setup                 |
+| 🟡 Medium | No off-site backup (S3) implemented          | `docs/DATABASE_BACKUP.md` |
+| 🟢 Low    | TimescaleDB compression not verified         | N/A                       |
 
 **Recommendations**:
+
 1. Verify cron job is running on VPS
 2. Implement S3 off-site backups before production
 3. Enable and verify TimescaleDB compression policies
@@ -279,6 +299,7 @@ Legal & Compliance   ████████░░ 8/10
 ### 8. Monitoring & Observability █████░░░░░ 5/10
 
 **Strengths**:
+
 - ✅ Health check endpoint with DB/Redis status
 - ✅ Degraded/unhealthy status codes
 - ✅ Uptime tracking in health response
@@ -287,15 +308,16 @@ Legal & Compliance   ████████░░ 8/10
 
 **Issues Found**:
 
-| Severity | Issue | Location |
-|----------|-------|----------|
-| 🔴 High | Sentry/APM not integrated | Package.json |
-| 🔴 High | No uptime monitoring configured | N/A |
-| 🟡 Medium | No alerting for error spikes | N/A |
-| 🟡 Medium | No dashboards configured | N/A |
-| 🟡 Medium | No SLA/SLO definitions | N/A |
+| Severity  | Issue                           | Location     |
+| --------- | ------------------------------- | ------------ |
+| 🔴 High   | Sentry/APM not integrated       | Package.json |
+| 🔴 High   | No uptime monitoring configured | N/A          |
+| 🟡 Medium | No alerting for error spikes    | N/A          |
+| 🟡 Medium | No dashboards configured        | N/A          |
+| 🟡 Medium | No SLA/SLO definitions          | N/A          |
 
 **Recommendations**:
+
 1. **CRITICAL**: Integrate Sentry before production (follow `docs/APM_SETUP.md`)
 2. Set up UptimeRobot or Pingdom for uptime monitoring
 3. Configure alerts for 5xx error spikes, response time degradation
@@ -306,12 +328,14 @@ Legal & Compliance   ████████░░ 8/10
 ### 9. Documentation █████████░ 9/10 (was 7/10)
 
 **Improvements Since Last Report**:
+
 - ✅ Operations runbook created (`docs/RUNBOOK.md`)
 - ✅ Database backup procedures added (`docs/DATABASE_BACKUP.md`)
 - ✅ APM setup guide added (`docs/APM_SETUP.md`)
 - ✅ Deployment documentation added (`docs/DEPLOYMENT.md`)
 
 **Strengths**:
+
 - ✅ Comprehensive README with setup instructions
 - ✅ API documentation (`docs/API.md`)
 - ✅ Operations runbook (`docs/RUNBOOK.md`)
@@ -324,12 +348,13 @@ Legal & Compliance   ████████░░ 8/10
 
 **Issues Found**:
 
-| Severity | Issue | Location |
-|----------|-------|----------|
-| 🟢 Low | Architecture diagrams not found | N/A |
-| 🟢 Low | Contributing guidelines missing | N/A |
+| Severity | Issue                           | Location |
+| -------- | ------------------------------- | -------- |
+| 🟢 Low   | Architecture diagrams not found | N/A      |
+| 🟢 Low   | Contributing guidelines missing | N/A      |
 
 **Recommendations**:
+
 1. Add architecture diagram to docs/
 2. Add CONTRIBUTING.md for open-source contribution guidelines
 
@@ -338,11 +363,13 @@ Legal & Compliance   ████████░░ 8/10
 ### 10. Legal & Compliance ████████░░ 8/10 (was 4/10)
 
 **Improvements Since Last Report**:
+
 - ✅ LICENSE file added (MIT)
 - ✅ Privacy Policy created (`docs/PRIVACY_POLICY.md`)
 - ✅ GDPR/CCPA considerations documented
 
 **Strengths**:
+
 - ✅ LICENSE file present (MIT)
 - ✅ Privacy Policy documented (`docs/PRIVACY_POLICY.md`)
 - ✅ GDPR/CCPA considerations documented
@@ -351,13 +378,14 @@ Legal & Compliance   ████████░░ 8/10
 
 **Issues Found**:
 
-| Severity | Issue | Location |
-|----------|-------|----------|
-| 🟡 Medium | Terms of Service not found | N/A |
-| 🟢 Low | Cookie consent banner not implemented | N/A |
-| 🟢 Low | Accessibility (WCAG) not audited | N/A |
+| Severity  | Issue                                 | Location |
+| --------- | ------------------------------------- | -------- |
+| 🟡 Medium | Terms of Service not found            | N/A      |
+| 🟢 Low    | Cookie consent banner not implemented | N/A      |
+| 🟢 Low    | Accessibility (WCAG) not audited      | N/A      |
 
 **Recommendations**:
+
 1. Add Terms of Service before public launch
 2. Implement cookie consent if using analytics cookies
 3. Consider accessibility audit for public-facing pages
@@ -366,55 +394,56 @@ Legal & Compliance   ████████░░ 8/10
 
 ## Critical Issues (Must Fix Before Production) 🚨
 
-| # | Issue | Category | Fix Complexity |
-|---|-------|----------|----------------|
-| 1 | Sentry/APM not integrated | Monitoring | 1-2 hours |
-| 2 | No uptime monitoring | Monitoring | 30 minutes |
-| 3 | 6 high npm vulnerabilities (d3-color) | Security | 1 hour |
+| #   | Issue                                 | Category   | Fix Complexity |
+| --- | ------------------------------------- | ---------- | -------------- |
+| 1   | Sentry/APM not integrated             | Monitoring | 1-2 hours      |
+| 2   | No uptime monitoring                  | Monitoring | 30 minutes     |
+| 3   | 6 high npm vulnerabilities (d3-color) | Security   | 1 hour         |
 
 ---
 
 ## High Priority (Should Fix) ⚠️
 
-| # | Issue | Category | Fix Complexity |
-|---|-------|----------|----------------|
-| 1 | CORS allows all origins for /api/v1/* | Security | 30 minutes |
-| 2 | Configure backup cron on VPS | Database | 15 minutes |
-| 3 | Add E2E tests for critical flows | Testing | 4-8 hours |
-| 4 | Add Terms of Service | Legal | 2 hours |
-| 5 | Implement off-site S3 backups | Database | 2 hours |
-| 6 | Add Content-Security-Policy header | Security | 30 minutes |
-| 7 | Set up pre-commit hooks | Testing | 30 minutes |
+| #   | Issue                                  | Category | Fix Complexity |
+| --- | -------------------------------------- | -------- | -------------- |
+| 1   | CORS allows all origins for /api/v1/\* | Security | 30 minutes     |
+| 2   | Configure backup cron on VPS           | Database | 15 minutes     |
+| 3   | Add E2E tests for critical flows       | Testing  | 4-8 hours      |
+| 4   | Add Terms of Service                   | Legal    | 2 hours        |
+| 5   | Implement off-site S3 backups          | Database | 2 hours        |
+| 6   | Add Content-Security-Policy header     | Security | 30 minutes     |
+| 7   | Set up pre-commit hooks                | Testing  | 30 minutes     |
 
 ---
 
 ## Medium Priority 📋
 
-| # | Issue | Category |
-|---|-------|----------|
-| 1 | Add request ID tracing | Error Handling |
-| 2 | Upgrade to pino logger | Error Handling |
-| 3 | Add resource limits to containers | Infrastructure |
-| 4 | Add architecture diagrams | Documentation |
-| 5 | Cookie consent implementation | Legal |
+| #   | Issue                             | Category       |
+| --- | --------------------------------- | -------------- |
+| 1   | Add request ID tracing            | Error Handling |
+| 2   | Upgrade to pino logger            | Error Handling |
+| 3   | Add resource limits to containers | Infrastructure |
+| 4   | Add architecture diagrams         | Documentation  |
+| 5   | Cookie consent implementation     | Legal          |
 
 ---
 
 ## Low Priority ✨
 
-| # | Issue | Category |
-|---|-------|----------|
-| 1 | Deprecate API key query param | Security |
-| 2 | Service worker for offline | Performance |
-| 3 | CONTRIBUTING.md | Documentation |
-| 4 | Accessibility audit | Legal |
-| 5 | LOG_LEVEL in .env.example | Environment |
+| #   | Issue                         | Category      |
+| --- | ----------------------------- | ------------- |
+| 1   | Deprecate API key query param | Security      |
+| 2   | Service worker for offline    | Performance   |
+| 3   | CONTRIBUTING.md               | Documentation |
+| 4   | Accessibility audit           | Legal         |
+| 5   | LOG_LEVEL in .env.example     | Environment   |
 
 ---
 
 ## Action Plan for Bounty Deadline (Dec 26, 2025)
 
 ### Day 1 (Dec 15) - Critical Fixes
+
 ```
 □ Integrate Sentry (2 hours)
   - npm install @sentry/nextjs
@@ -432,6 +461,7 @@ Legal & Compliance   ████████░░ 8/10
 ```
 
 ### Day 2 (Dec 16) - Deployment
+
 ```
 □ Deploy to VPS (2-4 hours)
   - Configure GitHub secrets (VPS_SSH_KEY, POSTGRES_PASSWORD)
@@ -445,6 +475,7 @@ Legal & Compliance   ████████░░ 8/10
 ```
 
 ### Days 3-10 (Dec 17-24) - Polish & Test
+
 ```
 □ Restrict CORS origins (30 minutes)
 □ Add Terms of Service (2 hours)
@@ -454,6 +485,7 @@ Legal & Compliance   ████████░░ 8/10
 ```
 
 ### Day 11 (Dec 25) - Submission Prep
+
 ```
 □ Final documentation review
 □ Screenshots and demo video
@@ -465,6 +497,7 @@ Legal & Compliance   ████████░░ 8/10
 ## Production Checklist
 
 ### Before Go-Live
+
 - [ ] All critical issues resolved
 - [ ] Score reaches 85+
 - [ ] Manual QA passed
@@ -474,6 +507,7 @@ Legal & Compliance   ████████░░ 8/10
 - [ ] Rollback procedure tested
 
 ### Post-Launch Monitoring
+
 - [ ] Watch error rates for 24 hours
 - [ ] Monitor response times
 - [ ] Check database query performance
@@ -483,38 +517,39 @@ Legal & Compliance   ████████░░ 8/10
 
 ## Tech Stack Summary
 
-| Component | Technology | Version |
-|-----------|------------|---------|
-| Frontend | Next.js | 16.0.7 |
-| Language | TypeScript | 5.x |
-| Styling | Tailwind CSS | 4.x |
-| API | tRPC | 11.0.0 |
-| Database | PostgreSQL + TimescaleDB | 16 |
-| Cache | Redis | 7 |
-| ORM | Prisma | 6.19.0 |
-| Testing | Vitest | 2.1.8 |
-| Deployment | Docker Compose | N/A |
-| CI/CD | GitHub Actions | N/A |
+| Component  | Technology               | Version |
+| ---------- | ------------------------ | ------- |
+| Frontend   | Next.js                  | 16.0.7  |
+| Language   | TypeScript               | 5.x     |
+| Styling    | Tailwind CSS             | 4.x     |
+| API        | tRPC                     | 11.0.0  |
+| Database   | PostgreSQL + TimescaleDB | 16      |
+| Cache      | Redis                    | 7       |
+| ORM        | Prisma                   | 6.19.0  |
+| Testing    | Vitest                   | 2.1.8   |
+| Deployment | Docker Compose           | N/A     |
+| CI/CD      | GitHub Actions           | N/A     |
 
 ---
 
 ## Progress Since Last Report (Dec 8 → Dec 15)
 
-| Category | Previous | Current | Change |
-|----------|----------|---------|--------|
-| Security | 6/10 | 8/10 | +2 |
-| Environment | 8/10 | 9/10 | +1 |
-| Error Handling | 7/10 | 7/10 | 0 |
-| Performance | 9/10 | 9/10 | 0 |
-| Testing | 4/10 | 7/10 | +3 |
-| Infrastructure | 8/10 | 9/10 | +1 |
-| Database | 9/10 | 8/10 | -1 (more scrutiny) |
-| Monitoring | 7/10 | 5/10 | -2 (stricter criteria) |
-| Documentation | 7/10 | 9/10 | +2 |
-| Legal | 4/10 | 8/10 | +4 |
-| **Overall** | **72/100** | **79/100** | **+7** |
+| Category       | Previous   | Current    | Change                 |
+| -------------- | ---------- | ---------- | ---------------------- |
+| Security       | 6/10       | 8/10       | +2                     |
+| Environment    | 8/10       | 9/10       | +1                     |
+| Error Handling | 7/10       | 7/10       | 0                      |
+| Performance    | 9/10       | 9/10       | 0                      |
+| Testing        | 4/10       | 7/10       | +3                     |
+| Infrastructure | 8/10       | 9/10       | +1                     |
+| Database       | 9/10       | 8/10       | -1 (more scrutiny)     |
+| Monitoring     | 7/10       | 5/10       | -2 (stricter criteria) |
+| Documentation  | 7/10       | 9/10       | +2                     |
+| Legal          | 4/10       | 8/10       | +4                     |
+| **Overall**    | **72/100** | **79/100** | **+7**                 |
 
 **Key Improvements Made**:
+
 1. JWT secret defaults removed
 2. LICENSE file added
 3. Privacy Policy created
@@ -525,6 +560,7 @@ Legal & Compliance   ████████░░ 8/10
 8. Security headers configured
 
 **Remaining Blockers**:
+
 1. Sentry integration (monitoring)
 2. Uptime monitoring setup
 3. npm vulnerability fixes
@@ -533,4 +569,4 @@ Legal & Compliance   ████████░░ 8/10
 
 **Report generated by CIPHER for pNode Pulse production readiness assessment.**
 
-*InshaAllah, with these improvements, pNode Pulse will be production-ready for the Superteam bounty submission! 🚀*
+_InshaAllah, with these improvements, pNode Pulse will be production-ready for the Superteam bounty submission! 🚀_


### PR DESCRIPTION
## What
Finishes the staging decommission (#237) across the remaining **current-state docs** and retires the stale **blue/green** deployment model (the project has been single-`green` since #221).

| Doc | Change |
|-----|--------|
| `CLAUDE.md` | staging checklist item removed; multi-env → single-container; bounty "READY TO SUBMIT" → submitted (3rd place) |
| `ROADMAP.md` | deploy topology table → single green (dropped blue/7000 + staging/7002; pg/redis internal; collector added) |
| `docs/RUNBOOK.md` | full blue/green → single-green rewrite; **fixed unsafe `docker system prune -a --volumes` → `image`/`builder prune`** (shared-VPS rule) |
| `docs/UPTIME_MONITORING.md` | staging monitor removed; `blue` → `green` commands |
| `docs/DATABASE_BACKUP.md` | staging refs → scratch/restore-test DB |
| `docs/APM_SETUP.md` | staging compose service removed; example service `blue` → `green` |
| `docs/SUBMISSION.md`, `docs/production-readiness-report.md` | corrected blue/green + staging capability claims |

## Intentionally left (historical / design — not current state)
- `CHANGELOG.md` — immutable history; you don't rewrite past entries
- `prisma/migrations/20251209060207_add_v070_fields/README.md` — frozen artifact of a completed migration
- `VERCEL_MIGRATION_HANDOFF.md` — migration plan; its decom steps get reworked when Tier 2 actually runs
- `docs/REDESIGN_*.md` — weigh a *hypothetical future staging API*, consistent with no staging env

## Deploy impact
Docs-only → `paths-ignore` means **no prod redeploy**. CI runs on the PR.