### PR TITLE
feat(fe): opt-in direct pulse-api URL via NEXT_PUBLIC_API_URL

### DIFF
--- a/src/lib/trpc/provider.tsx
+++ b/src/lib/trpc/provider.tsx
@@ -13,11 +13,19 @@ import superjson from "superjson";
 import { trpc } from "./client";
 
 function getBaseUrl() {
+  // If NEXT_PUBLIC_API_URL is set, route all tRPC traffic to the external
+  // pulse-api service (e.g. https://api.pulse.rectorspace.com). This is the
+  // Phase 3 cutover path — the Vercel-hosted FE talks to pulse-api on VPS
+  // instead of the monolith's local /api/trpc route handler.
+  // When unset, fall back to legacy behavior: relative path in the browser,
+  // localhost during SSR — i.e. the monolith handles tRPC itself.
+  const externalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (externalApiUrl) {
+    return externalApiUrl.replace(/\/+$/, "");
+  }
   if (typeof window !== "undefined") {
-    // Browser should use relative path
     return "";
   }
-  // SSR should use localhost
   return `http://localhost:${process.env.PORT ?? 3000}`;
 }
 
@@ -35,7 +43,7 @@ export function TRPCProvider({ children }: { children: React.ReactNode }) {
             refetchOnWindowFocus: true,
           },
         },
-      })
+      }),
   );
 
   const [trpcClient] = useState(() =>
@@ -46,7 +54,7 @@ export function TRPCProvider({ children }: { children: React.ReactNode }) {
           transformer: superjson,
         }),
       ],
-    })
+    }),
   );
 
   return (


### PR DESCRIPTION
## Summary

Adds an opt-in to the FE's tRPC provider so the browser can talk to pulse-api directly (e.g. `https://api.pulse.rectorspace.com`) instead of going through the Vercel rewrites configured in `next.config.ts`. Saves one hop on every tRPC request.

This is the front-end half of Phase 3 in the pnode-pulse redesign — the actual backend cutover happened at the nginx layer (api.pulse.rectorspace.com upstream switched from monolith green :7001 to pulse-api :7004) and is already live.

## Behavior

| `NEXT_PUBLIC_API_URL` | tRPC client URL | Notes |
|-----------------------|-----------------|-------|
| set (e.g. `https://api.pulse.rectorspace.com`) | `${NEXT_PUBLIC_API_URL}/api/trpc` directly | Skips the Vercel `rewrites()` hop in `next.config.ts` |
| unset | relative `/api/trpc` in browser, `http://localhost:${PORT}/api/trpc` during SSR | Current behavior — Vercel rewrites still apply if `PULSE_API_URL` is set |

## Composition with existing `PULSE_API_URL` rewrite

`next.config.ts` rewrites `/api/*` → `${PULSE_API_URL}/api/*` server-side, in `beforeFiles` (so it precedes the static API route handlers). That path still works untouched. `NEXT_PUBLIC_API_URL` is a complementary optimization that lets the browser skip the Next.js server hop entirely.

Both env vars can be set; they don't conflict. The browser uses `NEXT_PUBLIC_API_URL` directly, and the server-side rewrite path (for direct same-origin /api calls outside the tRPC client) still uses `PULSE_API_URL`.

## Test plan

- [x] `npm run typecheck` passes
- [x] Default behavior unchanged when env var unset (provider returns `""` in browser, `http://localhost:${PORT}` during SSR)
- [ ] After merge: set `NEXT_PUBLIC_API_URL=https://api.pulse.rectorspace.com` on Vercel → next deploy → confirm tRPC client URL in DevTools network tab points to api.pulse.rectorspace.com directly

## Rollback

Unset the env var on Vercel. The tRPC client falls back to the relative `/api/trpc` path and the Vercel rewrite handles routing as before.

## Context

- pulse-api service healthy on VPS reclabs3 port 7004 since 2026-06-02
- nginx upstream for api.pulse.rectorspace.com switched from :7001 → :7004 in this session (revert via the backup at /etc/nginx/sites-available/api.pulse.rectorspace.com.bak.20260602-043552 if needed)
- Monolith green container on :7001 still running as standby for now